### PR TITLE
feat: add user config file system (TOML)

### DIFF
--- a/.sisyphus/boulder.json
+++ b/.sisyphus/boulder.json
@@ -27,6 +27,15 @@
       "agent": "Sisyphus-Junior",
       "category": "deep",
       "updated_at": "2026-04-09T13:14:54.628Z"
+    },
+    "todo:5": {
+      "task_key": "todo:5",
+      "task_label": "5",
+      "task_title": "Replace TimeWindow enum with config-driven TimeWindowOption (ATOMIC)",
+      "session_id": "ses_28d9a8b31ffeO4F0J5hXqZQiaj",
+      "agent": "Sisyphus-Junior",
+      "category": "deep",
+      "updated_at": "2026-04-09T13:23:51.699Z"
     }
   }
 }

--- a/.sisyphus/boulder.json
+++ b/.sisyphus/boulder.json
@@ -1,64 +1,32 @@
 {
-  "active_plan": "/Users/joey/Sites/opencode-dashboard/.sisyphus/plans/opencode-dashboard.md",
-  "started_at": "2026-04-08T18:42:13.474Z",
+  "active_plan": "/Users/joey/Sites/opencode-dashboard/.sisyphus/plans/user-config.md",
+  "started_at": "2026-04-09T13:03:27.225Z",
   "session_ids": [
-    "ses_291ccbec6ffe6Zc2SLaUqUF7W1",
-    "ses_29152c332ffecN38hFtLmhyj7O",
-    "ses_291528154ffeSkQb6jzniHWm3A",
-    "ses_291521b6effeAdsQF1dEOtxCu0",
-    "ses_291519a20ffeBTsqGrL1kM02AL",
-    "ses_2913bccc6ffeUYbcZd65PzCrut",
-    "ses_2910c2335ffe7pLl6uRD3HsQxd",
-    "ses_2910c0cc0ffermYzJT66arNbhB"
+    "ses_290f0dd12ffeRRyhCQFfrcSmzb"
   ],
   "session_origins": {
-    "ses_291ccbec6ffe6Zc2SLaUqUF7W1": "direct",
-    "ses_29152c332ffecN38hFtLmhyj7O": "appended",
-    "ses_291528154ffeSkQb6jzniHWm3A": "appended",
-    "ses_291521b6effeAdsQF1dEOtxCu0": "appended",
-    "ses_291519a20ffeBTsqGrL1kM02AL": "appended",
-    "ses_2913bccc6ffeUYbcZd65PzCrut": "appended",
-    "ses_2910c2335ffe7pLl6uRD3HsQxd": "appended",
-    "ses_2910c0cc0ffermYzJT66arNbhB": "appended"
+    "ses_290f0dd12ffeRRyhCQFfrcSmzb": "direct"
   },
-  "plan_name": "opencode-dashboard",
+  "plan_name": "user-config",
   "agent": "atlas",
   "task_sessions": {
     "todo:1": {
       "task_key": "todo:1",
       "task_label": "1",
-      "task_title": "Project Scaffold + Go Module Init",
-      "session_id": "ses_291975e81ffeUdYPIv8KTSq4gg",
+      "task_title": "Add BurntSushi/toml dependency",
+      "session_id": "ses_28da6578affe5e0Uil7A40SXud",
       "agent": "Sisyphus-Junior",
       "category": "quick",
-      "updated_at": "2026-04-08T18:48:38.281Z"
+      "updated_at": "2026-04-09T13:06:50.256Z"
     },
-    "todo:4": {
-      "task_key": "todo:4",
-      "task_label": "4",
-      "task_title": "SQLite Connection Layer",
-      "session_id": "ses_291905bfaffefMyexYFo9oVRDM",
+    "todo:2": {
+      "task_key": "todo:2",
+      "task_label": "2",
+      "task_title": "Config package - struct, defaults, loading, validation (TDD)",
+      "session_id": "ses_28da413f3ffebOMIINGKRvzGgk",
       "agent": "Sisyphus-Junior",
-      "category": "quick",
-      "updated_at": "2026-04-08T18:53:17.454Z"
-    },
-    "todo:5": {
-      "task_key": "todo:5",
-      "task_label": "5",
-      "task_title": "Session Repository + Project Repository (TDD)",
-      "session_id": "ses_2918da658ffebbMchM7dNrcbmm",
-      "agent": "Sisyphus-Junior",
-      "category": "unspecified-high",
-      "updated_at": "2026-04-08T19:03:43.651Z"
-    },
-    "final-wave:f1": {
-      "task_key": "final-wave:f1",
-      "task_label": "F1",
-      "task_title": "**Plan Compliance Audit** - `oracle`",
-      "session_id": "ses_29108956effe5kBbGYSjYAUpp4",
-      "agent": "Sisyphus-Junior",
-      "category": "unspecified-high",
-      "updated_at": "2026-04-08T21:24:13.425Z"
+      "category": "deep",
+      "updated_at": "2026-04-09T13:14:54.628Z"
     }
   }
 }

--- a/.sisyphus/boulder.json
+++ b/.sisyphus/boulder.json
@@ -36,6 +36,41 @@
       "agent": "Sisyphus-Junior",
       "category": "deep",
       "updated_at": "2026-04-09T13:23:51.699Z"
+    },
+    "todo:7": {
+      "task_key": "todo:7",
+      "task_label": "7",
+      "task_title": "Wire config into FilterBarModel",
+      "session_id": "ses_28d938f40ffejT1Id01YVPzMZ1",
+      "agent": "Sisyphus-Junior",
+      "category": "unspecified-high",
+      "updated_at": "2026-04-09T13:30:45.586Z"
+    },
+    "todo:9": {
+      "task_key": "todo:9",
+      "task_label": "9",
+      "task_title": "Wire config into LayoutModel",
+      "session_id": "ses_28d8d3e48ffeGt9Ocmb7EFDA4e",
+      "agent": "Sisyphus-Junior",
+      "category": "deep",
+      "updated_at": "2026-04-09T13:37:18.983Z"
+    },
+    "todo:12": {
+      "task_key": "todo:12",
+      "task_label": "12",
+      "task_title": "main.go - Add --config flag, load config, bridge types, wire through",
+      "session_id": "ses_28d8769b8ffe57ogln6TbQ7hdL",
+      "agent": "Sisyphus-Junior",
+      "category": "deep",
+      "updated_at": "2026-04-09T13:45:09.429Z"
+    },
+    "final-wave:f1": {
+      "task_key": "final-wave:f1",
+      "task_label": "F1",
+      "task_title": "**Plan Compliance Audit** - `oracle`",
+      "session_id": "ses_28d815f53ffecS0ouy1LgWUgYI",
+      "agent": "oracle",
+      "updated_at": "2026-04-09T13:51:16.218Z"
     }
   }
 }

--- a/.sisyphus/notepads/user-config/decisions.md
+++ b/.sisyphus/notepads/user-config/decisions.md
@@ -1,0 +1,33 @@
+# Decisions - user-config
+
+## filter.Filter.Window Type
+Decision: `time.Duration` (resolved value, not the option struct or an index).
+Reason: Simplest; UI layer resolves config option to duration before building Filter.
+
+## Time Window "All" Position
+Decision: Always APPENDED LAST (not first).
+Reason: Issue spec says "All is always appended"; changes cycle order from "All->1d->3d->7d" to "1d->3d->7d->All".
+
+## XDG Path Resolution
+Decision: Check `$XDG_CONFIG_HOME/opencode-dashboard/config.toml`, fall back to `~/.config/opencode-dashboard/config.toml`.
+Reason: Issue spec says `~/.config/...`; `os.UserConfigDir()` returns `~/Library/Application Support` on macOS which is wrong for this feature.
+
+## Explicit --config with Missing File
+Decision: Return error (NOT silent fallback).
+Reason: If user explicitly specifies a path, they expect it to exist. Silent fallback would hide misconfiguration.
+
+## TOML Slice Replacement Semantics
+Decision: User-defined time windows REPLACE defaults entirely (not merged).
+Reason: BurntSushi/toml naturally replaces slices; this is documented and tested.
+
+## Unknown TOML Keys
+Decision: Warn to stderr (NOT error).
+Reason: Allows forward-compatibility; user has extra keys from a newer version, shouldn't break.
+
+## Space Key Alias
+Decision: "space" accepted as alias, normalized to " " internally.
+Reason: `" "` in TOML is confusing/error-prone for users.
+
+## sectionHeaderStyle
+Decision: Uses `ColorHeader` (shared accent color), not a separate config field.
+Reason: The same #7D56F4 accent appears everywhere; single configurable color is simpler.

--- a/.sisyphus/notepads/user-config/issues.md
+++ b/.sisyphus/notepads/user-config/issues.md
@@ -1,0 +1,24 @@
+# Issues - user-config
+
+## Known Gotchas
+
+### Task 5 is ATOMIC
+Task 5 touches domain/types.go, filter/filter.go, filter/filter_test.go, filterbar.go, app.go simultaneously. All must change in one commit or the build breaks. The executor must make all changes before running `go build ./...`.
+
+### KeysConfig vs KeyMap
+The `config.KeysConfig` struct (TOML tags for loading) and `config.KeyMap` struct (used by UI for matching) may be the same struct or related. The plan specifies KeyMap as the UI type with `Matches()` as a standalone function. The Keys field on Config is `KeysConfig` (with TOML tags). Whether these are unified is up to the executor - just ensure the UI components receive a KeyMap-compatible type.
+
+### ctrl+c Always Quits
+In `app.go`, ctrl+c must ALWAYS quit even during search mode. The simplest implementation: check Quit bindings normally, but keep a separate direct check for ctrl+c that bypasses search mode. Alternatively: check if keyStr is ctrl+c specifically from the Quit bindings.
+
+### headerStyle is a Package-Level Var
+Currently `var headerStyle = lipgloss.NewStyle()...` at package level. To make it config-aware, compute it in NewAppWithConfig() constructor and store on AppModel, then use the stored style in View(). Don't recreate per-render.
+
+### filterbar.go is Modified by Tasks 5, 7, AND 11
+Task 5 changes the window-related fields/constructor/cycling.
+Task 7 adds keys/display fields and replaces key checks.
+Task 11 replaces legend colors (may overlap with Task 7).
+These are sequential (7 depends on 5; 11 depends on 5,6), so no conflict in execution order.
+
+### Task 5 Interim Layout Default
+Until T9 expands `NewLayout()` config inputs, `internal/ui/layout.go` hardcodes the default window options and passes default index `1` to `NewFilterBar()` so the default remains `3d`.

--- a/.sisyphus/notepads/user-config/learnings.md
+++ b/.sisyphus/notepads/user-config/learnings.md
@@ -30,3 +30,8 @@
 - Default time window: 3d
 - ColorHeader: "#7D56F4"
 - Hardcoded keys: Up=["k","up"], Down=["j","down"], PaneLeft=["h"], PaneRight=["l","right"], TreeNav=["left"], Collapse=[" "], CycleFilter=["tab"], CycleTime=["t"], Search=["/"], Refresh=["r"], Launch=["enter"], Quit=["q","ctrl+c"]
+
+## Task 12 Completion Notes
+- `cmd/opencode-dashboard/main.go` now loads config immediately after flag parsing and reports failures with `Config error: ...` on stderr.
+- Attention thresholds are bridged from `config.Config` into `attention.Thresholds` in main, then injected through `app.NewAggregatorWithClassifier()`.
+- Go's standard `flag` help renders the new option as `-config`, even when callers pass `--config` on the command line.

--- a/.sisyphus/notepads/user-config/learnings.md
+++ b/.sisyphus/notepads/user-config/learnings.md
@@ -1,0 +1,32 @@
+# Learnings - user-config
+
+## Project Conventions
+- Module: `github.com/joeyparis/opencode-dashboard`
+- Go 1.25, all tests use `github.com/stretchr/testify/assert`
+- Test helper pattern: `fixedNow()` for deterministic time (see classifier_test.go:149)
+- UI models are value types (not pointers), stores/aggregator are pointer types
+- No CGO - using `modernc.org/sqlite` pure-Go driver
+
+## Package Boundaries (CRITICAL)
+- `internal/config` MUST NOT import any internal package - defines its own types
+- Conversion from `config.TimeWindowOption{Hours int}` to `domain.TimeWindowOption{Duration}` happens in `internal/ui/app.go`
+- Attention threshold conversion happens in `cmd/opencode-dashboard/main.go`
+- `internal/store/` must NOT be modified (config feature)
+
+## Key Architecture Facts
+- Aggregator.classify is `func(domain.SessionView, time.Time) domain.AttentionSignal` - inject via closure in main.go
+- `NewAggregator()` signature MUST stay unchanged; add `NewAggregatorWithClassifier()` alongside
+- `filter.Apply()` will gain a `now time.Time` parameter (testability fix, part of Task 5)
+- TimeWindow enum (iota) is FULLY REMOVED and replaced with `domain.TimeWindowOption{Label, Duration}`
+- "All" sentinel appended last: `{Label: "All", Duration: 0}`
+
+## Default Values (EXACT)
+- ActiveNowWindow: 5 minutes
+- NeedsResponseWindow: 24 hours
+- StaleThreshold: 7 days
+- RefreshInterval: 30 seconds
+- ListWidthRatio: 0.5
+- Default filter: needs_attention
+- Default time window: 3d
+- ColorHeader: "#7D56F4"
+- Hardcoded keys: Up=["k","up"], Down=["j","down"], PaneLeft=["h"], PaneRight=["l","right"], TreeNav=["left"], Collapse=[" "], CycleFilter=["tab"], CycleTime=["t"], Search=["/"], Refresh=["r"], Launch=["enter"], Quit=["q","ctrl+c"]

--- a/.sisyphus/plans/recent-messages-detail-pane.md
+++ b/.sisyphus/plans/recent-messages-detail-pane.md
@@ -1,0 +1,682 @@
+# feat: Recent Messages in Session Detail Pane
+
+## TL;DR
+
+> **Quick Summary**: Add a "Recent Messages" section to the detail pane showing the last 5 messages with truncated content previews (~100 chars). Replaces the current single-message "Last Activity" section with richer context.
+> 
+> **Deliverables**:
+> - `MessagePreview` domain type with role, agent, content snippet, timestamp
+> - `GetRecentMessages()` store method querying message + part tables
+> - Updated aggregator pre-fetching recent messages per session
+> - `renderRecentMessages()` replacing `renderLastActivity()` in detail pane
+> - Test fixtures with multi-message/multi-part data
+> - Store-level tests for the new method
+> 
+> **Estimated Effort**: Short (5 focused tasks)
+> **Parallel Execution**: YES - 2 waves
+> **Critical Path**: Task 1 (verify part JSON + types) -> Task 2 (store impl) -> Task 4 (UI render)
+> **GitHub Issue**: #2
+> **Branch**: `feat/2-recent-messages-detail-pane`
+
+---
+
+## Context
+
+### Original Request
+Add the last 2-5 messages with content previews to the session detail pane.
+
+### Interview Summary
+**Key Discussions**:
+- **Content display**: Truncated content previews (~80-120 chars), not just metadata
+- **Loading strategy**: User initially chose lazy-load, but Metis review identified that pre-fetch in the aggregator is architecturally simpler and consistent with every other field in `SessionView`. Pre-fetch chosen - see rationale below.
+
+**Loading Strategy Decision (Pre-fetch over Lazy Load)**:
+The current architecture has ZERO precedent for async loading triggered by selection change. Every piece of data in the detail pane comes pre-populated in `SessionView` by the aggregator. Introducing lazy loading would require:
+- A brand-new upward command flow pattern (detail -> layout -> app)
+- Race condition handling for rapid j/k navigation
+- Session ID matching to prevent stale data display
+- Manual re-fetch after the 30s auto-refresh cycle
+- Loading/empty states in the detail pane
+
+Pre-fetch adds one `LIMIT 5` JOIN query per session to the aggregator - negligible on local SQLite - and automatically refreshes every 30s via the existing cycle. Zero new patterns needed.
+
+### Metis Review
+**Identified Gaps** (addressed):
+- Part table JSON structure for text content is UNVERIFIED - added verification step as Task 1
+- Content truncation must flatten newlines to spaces
+- Messages with no text parts need graceful fallback
+- Display width vs char count for truncation (resolved: use rune count, not display width - keep it simple)
+- "Last Activity" section should be REPLACED, not supplemented
+
+---
+
+## Work Objectives
+
+### Core Objective
+Show the last 5 messages with truncated content previews in the session detail pane, replacing the current single-message "Last Activity" section.
+
+### Concrete Deliverables
+- `internal/domain/types.go` - `MessagePreview` struct
+- `internal/domain/interfaces.go` - `GetRecentMessages` on `MessageStore`
+- `internal/store/message.go` - SQL implementation
+- `internal/store/message_test.go` - Tests for new method
+- `internal/testutil/fixture.go` - Multi-message + text part fixtures
+- `internal/app/aggregator.go` - Pre-fetch recent messages
+- `internal/ui/detail.go` - `renderRecentMessages()` replacing `renderLastActivity()`
+
+### Definition of Done
+- [ ] `go test ./internal/... -v` passes with zero failures
+- [ ] `go vet ./internal/...` reports zero warnings
+- [ ] Detail pane shows up to 5 recent messages with truncated content
+- [ ] Zero-message sessions render gracefully (section hidden)
+- [ ] Messages with no text parts show `[tool use]` placeholder
+
+### Must Have
+- Content previews truncated to ~100 chars with `...` suffix
+- Newlines in content replaced with spaces before truncation
+- Leading/trailing whitespace trimmed
+- Role label per message (`user` / `assistant`)
+- Relative timestamps per message (existing `relativeTime()` pattern)
+- Graceful handling of 0, 1, and 5+ message counts
+
+### Must NOT Have (Guardrails)
+- No loading spinner or loading states (pre-fetch, data is always present)
+- No caching layer or mutex for messages (follow aggregator's existing pattern)
+- No width-responsive truncation (use fixed 100-char constant)
+- No different rendering per part type (text parts only, skip tool-invocation/error parts)
+- No "show more messages" link or pagination
+- No syntax highlighting or markdown rendering in previews
+- No collapsible/expandable message previews
+- No click-to-view-full-message interaction
+- No message count badge in section header
+
+---
+
+## Verification Strategy (MANDATORY)
+
+> **ZERO HUMAN INTERVENTION** - ALL verification is agent-executed. No exceptions.
+
+### Test Decision
+- **Infrastructure exists**: YES (Go test with `testutil.NewTestDB`)
+- **Automated tests**: YES (tests-after, following existing pattern)
+- **Framework**: `go test` with `testing` stdlib
+- **Pattern**: Follow `store/message_test.go` style - `testutil.NewTestDB(t)`, direct assertions
+
+### QA Policy
+Every task MUST include agent-executed QA scenarios.
+Evidence saved to `.sisyphus/evidence/task-{N}-{scenario-slug}.{ext}`.
+
+- **Store/Domain**: Use Bash (`go test`) - run tests, verify pass/fail counts
+- **UI rendering**: Use Bash (`go build ./...`) - verify compilation, then interactive_bash (tmux) to visually verify TUI against a real OpenCode DB if available
+
+---
+
+## Execution Strategy
+
+### Parallel Execution Waves
+
+```
+Wave 1 (Start Immediately - types + fixtures):
+├── Task 1: Verify part JSON structure + add domain types          [quick]
+├── Task 2: Seed multi-message test fixtures with text parts       [quick]
+└── Task 3: Add GetRecentMessages to MessageStore interface        [quick]
+
+Wave 2 (After Wave 1 - implementation + UI):
+├── Task 4: Implement GetRecentMessages store method + tests       [quick]
+│           (depends: 1, 2, 3)
+├── Task 5: Wire aggregator pre-fetch + update detail rendering    [unspecified-high]
+│           (depends: 4)
+
+Wave FINAL (After ALL tasks - 4 parallel reviews):
+├── F1: Plan compliance audit                                      [oracle]
+├── F2: Code quality review                                        [unspecified-high]
+├── F3: Real manual QA                                             [unspecified-high]
+└── F4: Scope fidelity check                                       [deep]
+-> Present results -> Get explicit user okay
+```
+
+### Dependency Matrix
+
+| Task | Depends On | Blocks | Wave |
+|------|-----------|--------|------|
+| 1    | -         | 4      | 1    |
+| 2    | -         | 4      | 1    |
+| 3    | -         | 4      | 1    |
+| 4    | 1, 2, 3   | 5      | 2    |
+| 5    | 4         | F1-F4  | 2    |
+
+### Agent Dispatch Summary
+
+- **Wave 1**: 3 tasks - T1 `quick`, T2 `quick`, T3 `quick`
+- **Wave 2**: 2 tasks - T4 `quick`, T5 `unspecified-high`
+- **FINAL**: 4 tasks - F1 `oracle`, F2 `unspecified-high`, F3 `unspecified-high`, F4 `deep`
+
+---
+
+## TODOs
+
+- [x] 1. Verify part table JSON structure + add MessagePreview domain type
+
+  **What to do**:
+  - Examine the real OpenCode database's `part` table to determine the exact JSON structure for text content parts. Run a query like:
+    ```sql
+    SELECT data FROM part WHERE json_extract(data, '$.type') = 'text' LIMIT 5;
+    ```
+    If no real DB is available, check the OpenCode source code (likely at `~/.opencode/` or check `cmd/opencode-dashboard/main.go` for the DB path pattern) to find the schema. The DB path pattern is `{project_worktree}/.opencode/state.db`.
+  - Once the JSON structure is confirmed, add `MessagePreview` struct to `internal/domain/types.go`:
+    ```go
+    type MessagePreview struct {
+        Role        string    // "user" or "assistant"
+        Agent       string
+        Content     string    // truncated content preview (~100 chars)
+        TimeCreated time.Time
+    }
+    ```
+  - Add `RecentMessages []MessagePreview` field to `SessionView` struct in `internal/domain/types.go`
+  - Record the verified JSON path (e.g., `$.text`, `$.content`, `$.value`) in the commit message for downstream tasks
+
+  **Must NOT do**:
+  - Do not write the SQL query yet - just verify the JSON path and add types
+  - Do not modify any store files
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Small type additions to two files, plus a DB inspection query
+  - **Skills**: []
+  - **Skills Evaluated but Omitted**:
+    - None needed for simple type additions
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 2, 3)
+  - **Blocks**: Task 4
+  - **Blocked By**: None
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/domain/types.go:66-73` - Existing `MessageMeta` struct pattern (role, agent, model, provider, time)
+  - `internal/domain/types.go:165-180` - `SessionView` struct where `RecentMessages` field should be added (after `LastMessage`)
+
+  **API/Type References**:
+  - `internal/testutil/fixture.go:72-78` - Schema showing `part` table structure: `id, message_id, session_id, time_created, time_updated, data`
+  - `internal/testutil/fixture.go:224-242` - Example of part JSON structure for tool-invocation type: `{"type": "tool-invocation", "state": {"status": "error"}}`
+
+  **External References**:
+  - OpenCode state DB location pattern: `{project_worktree}/.opencode/state.db` - look for any `.opencode/state.db` file on the filesystem
+
+  **WHY Each Reference Matters**:
+  - `MessageMeta` shows the existing field naming convention (Role, Agent, TimeCreated) - `MessagePreview` should match
+  - `SessionView` is where the new `RecentMessages` field goes - add it near `LastMessage` for logical grouping
+  - The fixture schema confirms `part.data` is a TEXT column with JSON - the exact JSON keys for text content need discovery
+  - The part fixture shows the pattern for other part types - text parts likely follow `{"type": "text", ...}`
+
+  **Acceptance Criteria**:
+  - [ ] `MessagePreview` struct added to `internal/domain/types.go` with Role, Agent, Content, TimeCreated fields
+  - [ ] `RecentMessages []MessagePreview` field added to `SessionView`
+  - [ ] `go build ./...` compiles successfully
+  - [ ] JSON path for text content parts documented (in code comment or commit message)
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: Types compile and are accessible
+    Tool: Bash
+    Preconditions: Working Go module
+    Steps:
+      1. Run `go build ./...`
+      2. Run `go vet ./internal/domain/...`
+    Expected Result: Exit code 0 for both commands, zero errors
+    Failure Indicators: Compilation errors, undefined type references
+    Evidence: .sisyphus/evidence/task-1-types-compile.txt
+
+  Scenario: Part JSON structure verified
+    Tool: Bash
+    Preconditions: At least one `.opencode/state.db` exists on the filesystem
+    Steps:
+      1. Find a real state.db: `find ~/Sites -name "state.db" -path "*/.opencode/*" 2>/dev/null | head -1`
+      2. Query text parts: `sqlite3 <db_path> "SELECT data FROM part WHERE json_extract(data, '$.type') = 'text' LIMIT 3;"`
+      3. If no text parts found, try: `sqlite3 <db_path> "SELECT DISTINCT json_extract(data, '$.type') FROM part LIMIT 20;"`
+    Expected Result: JSON structure revealed showing the field name for text content
+    Failure Indicators: No state.db found, no text parts exist, unexpected JSON structure
+    Evidence: .sisyphus/evidence/task-1-part-json-structure.txt
+  ```
+
+  **Commit**: YES (group 1)
+  - Message: `feat(domain): add MessagePreview type and GetRecentMessages interface`
+  - Files: `internal/domain/types.go`
+  - Pre-commit: `go build ./...`
+
+- [x] 2. Seed multi-message test fixtures with text parts
+
+  **What to do**:
+  - Update `internal/testutil/fixture.go` `seedData()` to insert multiple messages per session, with text parts containing actual content. Target sessions:
+    - `ses-needs-response`: 5+ messages (user/assistant alternating) with text parts - tests the "full list" case
+    - `ses-active-now`: 2 messages with text parts - tests the "fewer than limit" case
+    - `ses-has-errors`: Keep existing messages + add a message with ONLY tool-invocation parts (no text) - tests the "no text content" case
+    - `ses-archived`: Keep at 0 messages - tests the "empty" case
+  - Each text part should have realistic-ish content strings of varying lengths:
+    - Some short (< 100 chars) - no truncation needed
+    - Some long (> 100 chars) - truncation required
+    - Some with newlines - flattening required
+    - Some with leading/trailing whitespace - trimming required
+  - Use the verified JSON path from Task 1 for text part data structure. If Task 1 found `$.text`, then: `{"type": "text", "text": "content here"}`
+  - Update existing test assertions in `message_test.go` if message counts changed (e.g., `ses-needs-response` count changes from 1 to 5+)
+
+  **Must NOT do**:
+  - Do not add any new test functions yet (that's Task 4)
+  - Do not modify the schema - only add seed data
+  - Keep existing fixture data intact - only ADD to it
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Fixture data seeding following established patterns
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 1, 3)
+  - **Blocks**: Task 4
+  - **Blocked By**: None (but should use Task 1's verified JSON path if available; if not, use best guess `{"type": "text", "text": "..."}` and adjust later)
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/testutil/fixture.go:189-222` - Existing message seeding pattern: map of sessionID -> message info, JSON marshaling, INSERT with time_created as UnixMilli
+  - `internal/testutil/fixture.go:224-242` - Existing part seeding pattern for error parts: JSON with `type` and nested fields
+
+  **Test References**:
+  - `internal/store/message_test.go:70-83` - `TestGetMessageCount` asserts count=1 for `ses-needs-response` - THIS WILL BREAK if we add more messages. Must update assertion.
+  - `internal/store/message_test.go:10-35` - `TestGetLastMessageMeta_AssistantRole` checks role/agent/model of last message for `ses-needs-response` - ensure the LAST seeded message still has role=assistant, agent=Sisyphus, model=claude-haiku-4-5
+
+  **WHY Each Reference Matters**:
+  - Message seeding pattern shows the exact INSERT format and JSON structure to follow
+  - Part seeding pattern shows how to create parts linked to messages via `message_id`
+  - The existing test assertions are fragile to fixture changes - must preserve the last message's properties and update count assertions
+
+  **Acceptance Criteria**:
+  - [ ] `ses-needs-response` has 5+ messages with text parts
+  - [ ] `ses-active-now` has 2+ messages with text parts
+  - [ ] `ses-has-errors` has at least one message with only tool-invocation parts (no text)
+  - [ ] `ses-archived` still has 0 messages
+  - [ ] Text part content includes: short strings, long strings (>100 chars), strings with newlines, strings with whitespace
+  - [ ] `go test ./internal/... -v` passes - all existing tests still work
+  - [ ] `TestGetMessageCount` for `ses-needs-response` updated to expect new count
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: All existing tests pass with updated fixtures
+    Tool: Bash
+    Preconditions: Fixtures updated with new seed data
+    Steps:
+      1. Run `go test ./internal/... -v`
+      2. Verify zero FAIL lines in output
+      3. Verify `TestGetLastMessageMeta_AssistantRole` still passes (last message still assistant/Sisyphus)
+    Expected Result: All tests PASS, zero failures
+    Failure Indicators: Any FAIL in test output, especially message_test.go tests
+    Evidence: .sisyphus/evidence/task-2-existing-tests-pass.txt
+
+  Scenario: Fixture data is queryable
+    Tool: Bash
+    Preconditions: Test DB created with new fixtures
+    Steps:
+      1. Write a quick Go test that creates the test DB and counts messages per session:
+         `SELECT session_id, COUNT(*) FROM message GROUP BY session_id`
+      2. Verify ses-needs-response has 5+, ses-active-now has 2+, ses-archived has 0
+      3. Verify text parts exist: `SELECT COUNT(*) FROM part WHERE json_extract(data, '$.type') = 'text'`
+    Expected Result: Expected counts per session, text parts seeded
+    Failure Indicators: Wrong counts, zero text parts
+    Evidence: .sisyphus/evidence/task-2-fixture-counts.txt
+  ```
+
+  **Commit**: YES (group 2)
+  - Message: `test(fixture): seed multi-message fixtures with text parts`
+  - Files: `internal/testutil/fixture.go`, `internal/store/message_test.go`
+  - Pre-commit: `go test ./internal/store/... -v`
+
+- [x] 3. Add GetRecentMessages to MessageStore interface
+
+  **What to do**:
+  - Add `GetRecentMessages(ctx context.Context, sessionID string, limit int) ([]domain.MessagePreview, error)` to the `MessageStore` interface in `internal/domain/interfaces.go`
+  - This is interface-only - no implementation yet
+
+  **Must NOT do**:
+  - Do not implement the method on `MessageRepo` yet (Task 4)
+  - Do not modify any other interfaces
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Single line addition to an interface
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 1, 2)
+  - **Blocks**: Task 4
+  - **Blocked By**: None
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/domain/interfaces.go:16-19` - `MessageStore` interface with existing methods `GetLastMessageMeta` and `GetMessageCount`
+
+  **API/Type References**:
+  - `internal/domain/types.go` - `MessagePreview` type added in Task 1 (the return type)
+
+  **WHY Each Reference Matters**:
+  - The interface shows the exact signature pattern: `ctx context.Context` first, session ID second, return `(type, error)`
+  - Method should follow naming convention: `Get` prefix, descriptive name
+
+  **Acceptance Criteria**:
+  - [ ] `GetRecentMessages` method added to `MessageStore` interface
+  - [ ] Signature matches: `GetRecentMessages(ctx context.Context, sessionID string, limit int) ([]domain.MessagePreview, error)`
+  - [ ] NOTE: `go build` will FAIL after this because `MessageRepo` doesn't implement the new method yet - this is expected and will be fixed in Task 4. Verify with `go vet ./internal/domain/...` instead.
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: Interface is syntactically valid
+    Tool: Bash
+    Preconditions: Method added to interface
+    Steps:
+      1. Run `go vet ./internal/domain/...`
+    Expected Result: Zero errors from domain package
+    Failure Indicators: Syntax errors, invalid type references
+    Evidence: .sisyphus/evidence/task-3-interface-valid.txt
+  ```
+
+  **Commit**: YES (group with Task 1)
+  - Message: `feat(domain): add MessagePreview type and GetRecentMessages interface`
+  - Files: `internal/domain/interfaces.go` (combined with Task 1's types.go)
+  - Pre-commit: `go vet ./internal/domain/...`
+
+- [x] 4. Implement GetRecentMessages store method + tests
+
+  **What to do**:
+  - Implement `GetRecentMessages` on `MessageRepo` in `internal/store/message.go`
+  - SQL query should:
+    1. Select the N most recent messages for a session (ORDER BY time_created DESC LIMIT ?)
+    2. For each message, extract the first text part's content via a subquery on the `part` table
+    3. Use `json_extract(m.data, '$.role')` for role and `json_extract(m.data, '$.agent')` for agent (following existing pattern at line 23-28)
+    4. Use the verified JSON path from Task 1 for text content extraction from parts
+    5. Truncate content in Go code (not SQL) - `SUBSTR` in SQLite doesn't handle rune boundaries well
+  - Content processing in Go (after SQL fetch):
+    1. Replace all newlines (`\n`, `\r\n`, `\r`) with single space
+    2. Trim leading/trailing whitespace
+    3. If content length > 100 runes, truncate to 100 runes and append `...`
+    4. If no text parts found for a message, set Content to `[tool use]`
+  - Define a constant `maxPreviewLen = 100` in `message.go`
+  - Return messages in reverse chronological order (newest first) - same as the SQL ORDER BY
+  - Add compile-time interface check: the existing `var _ domain.MessageStore = (*MessageRepo)(nil)` at line 12 will enforce this
+  - Write tests in `internal/store/message_test.go`:
+    - `TestGetRecentMessages_MultipleMessages` - ses-needs-response has 5+ messages, request limit 5, verify count and order
+    - `TestGetRecentMessages_NoMessages` - ses-archived, expect empty slice (not nil)
+    - `TestGetRecentMessages_SingleMessage` - use a session with exactly 1 message
+    - `TestGetRecentMessages_ContentTruncation` - verify long content is truncated to 100 chars + `...`
+    - `TestGetRecentMessages_NewlineFlattening` - verify newlines replaced with spaces
+    - `TestGetRecentMessages_NoTextParts` - ses-has-errors tool-only message, expect `[tool use]` content
+
+  **Must NOT do**:
+  - Do not use SQLite `SUBSTR` for truncation - handle in Go for proper rune support
+  - Do not add a cache or mutex
+  - Do not modify the schema or add indexes (existing `message_session_time_created_id_idx` covers the query)
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Single store method with SQL query + Go processing, following established patterns exactly
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO
+  - **Parallel Group**: Wave 2 (sequential after Wave 1)
+  - **Blocks**: Task 5
+  - **Blocked By**: Tasks 1, 2, 3
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/store/message.go:22-60` - `GetLastMessageMeta` SQL query pattern: `json_extract` on `data` column, `COALESCE` for NULL safety, `time.UnixMilli().UTC()` for timestamp conversion, `sql.ErrNoRows` handling
+  - `internal/store/message_test.go:10-35` - Test pattern: `testutil.NewTestDB(t)`, `defer db.Close()`, `NewMessageRepo(db)`, direct field assertions
+
+  **API/Type References**:
+  - `internal/domain/types.go` - `MessagePreview` struct (from Task 1) - the return type
+  - `internal/domain/interfaces.go` - `GetRecentMessages` signature (from Task 3)
+
+  **Test References**:
+  - `internal/store/message_test.go` - All existing test patterns to follow
+  - `internal/testutil/fixture.go` - Fixture data from Task 2 determines expected test values
+
+  **External References**:
+  - SQLite JSON functions: `json_extract(column, '$.path')` - https://www.sqlite.org/json1.html
+
+  **WHY Each Reference Matters**:
+  - `GetLastMessageMeta` is the exact pattern to extend - same table, same JSON extraction, similar query structure
+  - Test patterns show the exact setup/teardown and assertion style to follow
+  - The fixture data from Task 2 determines what values the tests should expect
+
+  **Acceptance Criteria**:
+  - [ ] `GetRecentMessages` implemented on `MessageRepo`
+  - [ ] Compile-time interface check passes (existing `var _` line)
+  - [ ] 6 new tests written and passing
+  - [ ] `go test ./internal/store/... -v -run TestGetRecentMessages` shows 6 PASS
+  - [ ] Content truncation at 100 runes + `...` verified by test
+  - [ ] Newline flattening verified by test
+  - [ ] `[tool use]` fallback verified by test
+  - [ ] `go test ./internal/... -v` all pass (no regressions)
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: All GetRecentMessages tests pass
+    Tool: Bash
+    Preconditions: Store method implemented, fixtures seeded (Tasks 1-3 complete)
+    Steps:
+      1. Run `go test ./internal/store/... -v -run TestGetRecentMessages`
+      2. Count PASS lines - expect 6
+      3. Count FAIL lines - expect 0
+    Expected Result: 6 tests pass, 0 failures
+    Failure Indicators: Any FAIL, unexpected test count, compilation errors
+    Evidence: .sisyphus/evidence/task-4-store-tests.txt
+
+  Scenario: No regressions in existing tests
+    Tool: Bash
+    Preconditions: All changes from Tasks 1-4 applied
+    Steps:
+      1. Run `go test ./internal/... -v`
+      2. Verify zero FAIL lines
+      3. Verify test count >= previous count (no tests removed)
+    Expected Result: All existing + new tests PASS
+    Failure Indicators: Any FAIL line, reduced test count
+    Evidence: .sisyphus/evidence/task-4-no-regressions.txt
+
+  Scenario: Empty session returns empty slice (not nil)
+    Tool: Bash
+    Preconditions: TestGetRecentMessages_NoMessages test exists
+    Steps:
+      1. Run `go test ./internal/store/... -v -run TestGetRecentMessages_NoMessages`
+      2. Verify PASS
+    Expected Result: Returns empty []MessagePreview{}, not nil
+    Failure Indicators: nil pointer, FAIL
+    Evidence: .sisyphus/evidence/task-4-empty-session.txt
+  ```
+
+  **Commit**: YES (group 3)
+  - Message: `feat(store): implement GetRecentMessages with content preview`
+  - Files: `internal/store/message.go`, `internal/store/message_test.go`
+  - Pre-commit: `go test ./internal/store/... -v`
+
+- [x] 5. Wire aggregator pre-fetch + update detail pane rendering
+
+  **What to do**:
+  - **Aggregator** (`internal/app/aggregator.go`):
+    - In the `LoadAll` loop (lines 73-108), add a call to fetch recent messages:
+      ```go
+      recentMsgs, _ := a.messages.GetRecentMessages(ctx, s.ID, 5)
+      ```
+    - Add `RecentMessages: recentMsgs` to the `SessionView` construction (around line 92-105)
+    - The `_ =` error handling follows the existing pattern for non-critical data (same as todos, lastMsg, msgCount)
+  - **Aggregator test** (`internal/app/aggregator_test.go`):
+    - Update the mock `MessageStore` to implement `GetRecentMessages` (return empty slice)
+    - Verify the aggregator passes through the recent messages to `SessionView`
+  - **Detail pane** (`internal/ui/detail.go`):
+    - Replace `renderLastActivity()` with `renderRecentMessages()` in the `View()` sections array (line 72)
+    - Remove the `renderLastActivity()` method entirely (lines 182-203)
+    - Implement `renderRecentMessages()`:
+      - If `m.session.RecentMessages` is empty, return `""` (section hidden)
+      - Section header: `sectionHeaderStyle.Render("Recent Messages")`
+      - For each message, render a line like:
+        ```
+          user  3m ago  Can you help me fix the login bug?
+          asst  2m ago  I'll look into the login handler...
+        ```
+      - Role should be left-aligned and abbreviated: `user` / `asst` (4 chars each for alignment)
+      - Use `relativeTime()` for timestamps (existing helper)
+      - Content on the same line, after timestamp
+      - If the detail pane is narrow and content wraps, that's fine - lipgloss handles it
+
+  **Must NOT do**:
+  - Do not add loading states or spinners
+  - Do not add lazy loading mechanism
+  - Do not modify the `SetSession` method signature
+  - Do not add width-responsive truncation
+  - Do not add message count badges
+  - Do not add collapsible sections
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+    - Reason: Touches 3+ files across aggregator and UI layers, needs careful integration
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO
+  - **Parallel Group**: Wave 2 (after Task 4)
+  - **Blocks**: F1-F4
+  - **Blocked By**: Task 4
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/app/aggregator.go:73-108` - The per-session loop where all data is fetched. Add `GetRecentMessages` call alongside existing `GetLastMessageMeta`, `GetMessageCount`, etc.
+  - `internal/ui/detail.go:182-203` - `renderLastActivity()` - the method being REPLACED. Shows section header + metadata line rendering pattern.
+  - `internal/ui/detail.go:67-73` - `View()` sections array where `renderLastActivity` needs to become `renderRecentMessages`
+  - `internal/ui/detail.go:165-179` - `renderTodos()` - similar list-rendering pattern with icons and formatted lines
+  - `internal/ui/styles.go` - `sectionHeaderStyle` and other style definitions
+
+  **API/Type References**:
+  - `internal/domain/types.go` - `SessionView.RecentMessages []MessagePreview` (from Task 1)
+  - `internal/domain/types.go` - `MessagePreview` struct fields: Role, Agent, Content, TimeCreated
+
+  **Test References**:
+  - `internal/app/aggregator_test.go` - Existing mock-based aggregator tests. The mock `MessageStore` needs to implement the new `GetRecentMessages` method.
+
+  **WHY Each Reference Matters**:
+  - The aggregator loop shows exactly WHERE to add the fetch call and HOW to handle errors (ignore with `_`)
+  - `renderLastActivity` is the method being replaced - understand its structure before removing
+  - `renderTodos` shows how to render a list of items with formatting - similar pattern for messages
+  - The aggregator test mock must be updated or tests will fail to compile
+
+  **Acceptance Criteria**:
+  - [ ] Aggregator fetches recent messages per session in `LoadAll`
+  - [ ] `SessionView.RecentMessages` populated with up to 5 messages
+  - [ ] `renderLastActivity()` removed entirely from detail.go
+  - [ ] `renderRecentMessages()` renders messages with role, relative time, and content preview
+  - [ ] Empty `RecentMessages` results in section being hidden (not rendered)
+  - [ ] Aggregator test mock updated, all aggregator tests pass
+  - [ ] `go test ./internal/... -v` all pass
+  - [ ] `go build ./cmd/...` compiles successfully
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: Full build + test pass
+    Tool: Bash
+    Preconditions: All Tasks 1-5 complete
+    Steps:
+      1. Run `go build ./cmd/...`
+      2. Run `go test ./internal/... -v`
+      3. Run `go vet ./internal/...`
+    Expected Result: All three commands exit 0, zero FAIL lines in test output
+    Failure Indicators: Build errors, test failures, vet warnings
+    Evidence: .sisyphus/evidence/task-5-full-build-test.txt
+
+  Scenario: Detail pane renders messages correctly (visual inspection via build)
+    Tool: Bash
+    Preconditions: Binary builds successfully
+    Steps:
+      1. Run `go build -o /tmp/ocd-test ./cmd/opencode-dashboard/`
+      2. If a real OpenCode state.db exists, run: `/tmp/ocd-test --db <path-to-state.db>` in tmux
+      3. Navigate to a session with messages using j/k keys
+      4. Verify the detail pane shows "Recent Messages" section with role labels and content
+      5. Capture screenshot or terminal output
+    Expected Result: "Recent Messages" section visible with formatted message previews
+    Failure Indicators: Missing section, garbled output, panic
+    Evidence: .sisyphus/evidence/task-5-detail-pane-render.png
+
+  Scenario: Zero-message session hides Recent Messages section
+    Tool: Bash
+    Preconditions: Binary builds, navigating to archived session
+    Steps:
+      1. Navigate to an archived/empty session
+      2. Verify "Recent Messages" section is NOT shown
+    Expected Result: Section absent, no empty header or blank space
+    Failure Indicators: Empty "Recent Messages" header with no content below
+    Evidence: .sisyphus/evidence/task-5-zero-messages.png
+  ```
+
+  **Commit**: YES (group 4)
+  - Message: `feat(ui): show recent messages in detail pane`
+  - Files: `internal/app/aggregator.go`, `internal/app/aggregator_test.go`, `internal/ui/detail.go`
+  - Pre-commit: `go test ./internal/... -v`
+
+---
+
+## Final Verification Wave (MANDATORY - after ALL implementation tasks)
+
+> 4 review agents run in PARALLEL. ALL must APPROVE. Present consolidated results to user and get explicit "okay" before completing.
+
+- [x] F1. **Plan Compliance Audit** - `oracle`
+  Read the plan end-to-end. For each "Must Have": verify implementation exists (read file, run command). For each "Must NOT Have": search codebase for forbidden patterns - reject with file:line if found. Check evidence files exist in .sisyphus/evidence/. Compare deliverables against plan.
+  Output: `Must Have [N/N] | Must NOT Have [N/N] | Tasks [N/N] | VERDICT: APPROVE/REJECT`
+
+- [x] F2. **Code Quality Review** - `unspecified-high`
+  Run `go vet ./internal/...` + `go test ./internal/... -v`. Review all changed files for: type assertion errors, unhandled errors, empty string comparisons vs len checks, hardcoded magic numbers. Check AI slop: excessive comments, over-abstraction, generic variable names.
+  Output: `Build [PASS/FAIL] | Vet [PASS/FAIL] | Tests [N pass/N fail] | Files [N clean/N issues] | VERDICT`
+
+- [x] F3. **Real Manual QA** - `unspecified-high`
+  Start from clean state. Execute EVERY QA scenario from EVERY task - follow exact steps, capture evidence. Test cross-task integration (messages appearing in detail pane with correct content). Test edge cases: zero messages, single message, tool-only messages. Save to `.sisyphus/evidence/final-qa/`.
+  Output: `Scenarios [N/N pass] | Integration [N/N] | Edge Cases [N tested] | VERDICT`
+
+- [x] F4. **Scope Fidelity Check** - `deep`
+  For each task: read "What to do", read actual diff (`git diff main`). Verify 1:1 - everything in spec was built, nothing beyond spec was built. Check "Must NOT do" compliance. Detect cross-task contamination. Flag unaccounted changes.
+  Output: `Tasks [N/N compliant] | Contamination [CLEAN/N issues] | Unaccounted [CLEAN/N files] | VERDICT`
+
+---
+
+## Commit Strategy
+
+| # | Message | Files | Pre-commit |
+|---|---------|-------|------------|
+| 1 | `feat(domain): add MessagePreview type and GetRecentMessages interface` | types.go, interfaces.go | `go build ./...` |
+| 2 | `test(store): seed multi-message fixtures with text parts` | fixture.go, fixture_test.go | `go test ./internal/testutil/...` |
+| 3 | `feat(store): implement GetRecentMessages with content preview` | message.go, message_test.go | `go test ./internal/store/...` |
+| 4 | `feat(ui): show recent messages in detail pane` | aggregator.go, detail.go | `go test ./internal/...` |
+
+---
+
+## Success Criteria
+
+### Verification Commands
+```bash
+go test ./internal/... -v        # Expected: all PASS, 0 failures
+go vet ./internal/...            # Expected: zero warnings  
+go build ./cmd/...               # Expected: successful build
+```
+
+### Final Checklist
+- [ ] All "Must Have" items present and verified
+- [ ] All "Must NOT Have" items absent (no loading spinners, no caching, no responsive truncation)
+- [ ] All existing tests still pass
+- [ ] New tests cover: multi-message, zero-message, single-message, no-text-parts scenarios
+- [ ] Detail pane renders recent messages section correctly
+- [ ] GitHub issue #2 acceptance criteria met

--- a/.sisyphus/plans/user-config.md
+++ b/.sisyphus/plans/user-config.md
@@ -1,0 +1,1575 @@
+# User Config File System (Issue #1)
+
+## TL;DR
+
+> **Quick Summary**: Add an optional TOML config file (`~/.config/opencode-dashboard/config.toml`) so users can customize keybindings, default filters/time windows, attention thresholds, and display colors/icons without recompiling. All current behavior is preserved when no config file exists.
+> 
+> **Deliverables**:
+> - New `internal/config/` package (Config struct, TOML loading, KeyMap, validation)
+> - Configurable attention thresholds in `internal/attention/`
+> - TimeWindow enum replaced with config-driven `[]TimeWindowOption` slice
+> - All UI components wired to accept config (keys, icons, colors, defaults, split ratio)
+> - `--config` flag in main.go
+> - Full TDD test coverage for config loading, key matching, threshold application
+> 
+> **Estimated Effort**: Medium-Large
+> **Parallel Execution**: YES - 4 waves
+> **Critical Path**: Task 1 -> Task 2 -> Task 5 -> Tasks 7-11 -> Task 12 -> F1-F4
+
+---
+
+## Context
+
+### Original Request
+GitHub issue #1 on joeyparis/opencode-dashboard: Add a TOML config file for customizing the Go/Bubbletea TUI dashboard. The dashboard reads OpenCode's SQLite database and shows session status with attention signals. Currently all keybindings, thresholds, colors, and defaults are hardcoded.
+
+### Interview Summary
+**Key Discussions**:
+- TimeWindow enum replacement: User confirmed full replacement with config-driven `[]TimeWindowOption{Label, Duration}` slice, dropping the iota enum entirely
+- TOML library: `github.com/BurntSushi/toml` (user's choice from issue)
+- Config flows as a struct through constructors - no globals
+- TDD approach with existing test infrastructure (go test + testify/assert)
+
+**Research Findings**:
+- Codebase has 11 existing test files, all using testify/assert with table-driven patterns
+- Aggregator already stores classify as `func(SessionView, time.Time) AttentionSignal` - supports closure injection for configurable thresholds with zero struct changes
+- All UI constructors are minimal-arg value-returning types - clean extension points
+- Two parallel icon functions exist (`attentionIcon` colored + `attentionIconPlain` uncolored) - both need DisplayConfig
+- `matchesWindow()` in filter.go calls `time.Now()` directly (untestable) - will fix as part of TimeWindow replacement
+- No existing UI tests - constructor signature changes are safe from test breakage
+
+### Metis Review
+**Identified Gaps** (addressed):
+- `filter.Filter.Window` type after enum removal: resolved as `time.Duration` (simplest, UI resolves option to duration before building Filter)
+- `matchesWindow()` testability: will accept `now time.Time` parameter (trivial scope addition, improves test quality)
+- XDG path resolution: follow issue spec (`~/.config/` default), not `os.UserConfigDir()` which returns `~/Library/Application Support` on macOS
+- Explicit `--config path` with missing file = error (different from silent fallback when no path specified)
+- Space key TOML representation: accept `"space"` alias, normalize to `" "` internally
+- TOML slice replacement semantics: BurntSushi/toml replaces slices entirely (user-defined windows replace all defaults, not merge). Document and test.
+- Unknown TOML keys: use `MetaData.Undecoded()` to warn on stderr, not error
+- `attentionIconPlain()` still needed for selected-row rendering - DisplayConfig provides raw icon string, styled variant wraps with color
+
+---
+
+## Work Objectives
+
+### Core Objective
+Add a user-facing TOML configuration file that controls keybindings, attention thresholds, display icons/colors, default filter/time settings, refresh interval, and pane layout - while preserving identical behavior when no config file is present.
+
+### Concrete Deliverables
+- `internal/config/config.go` - Config struct with TOML tags, Default(), Load(), ResolvePath(), Validate()
+- `internal/config/keys.go` - KeyMap struct with Matches() helper
+- `internal/config/config_test.go` - Full loading/merging/validation tests
+- `internal/config/keys_test.go` - KeyMap matching tests
+- Modified `internal/attention/classifier.go` with Thresholds struct + ClassifyWith()
+- Modified `internal/domain/types.go` - TimeWindowOption replaces TimeWindow enum
+- Modified `internal/filter/filter.go` - Duration-based window matching with `now` parameter
+- Modified UI files (app.go, layout.go, sessionlist.go, filterbar.go, styles.go) - config-driven keys/icons/colors/defaults
+- Modified `cmd/opencode-dashboard/main.go` - `--config` flag, config loading, type bridging
+- Updated `go.mod` with `github.com/BurntSushi/toml`
+
+### Definition of Done
+- [ ] `go test ./...` passes (all existing + new tests)
+- [ ] `go build ./cmd/opencode-dashboard` succeeds
+- [ ] `go vet ./...` clean
+- [ ] Running without config file produces identical behavior to current
+- [ ] Running with partial config merges onto defaults correctly
+- [ ] Parse errors produce clear messages with filename and exit non-zero
+
+### Must Have
+- Config loaded once at startup, immutable after Load() returns
+- Missing config file = silent fallback to defaults (no error)
+- Parse error = clear error message to stderr and os.Exit(1)
+- `--config` flag with explicit path that doesn't exist = error (different from silent fallback)
+- All `[defaults]` fields functional (filter, time_window, refresh_interval, list_width_ratio)
+- All `[thresholds]` fields functional (active_now_minutes, needs_response_hours, stale_work_days)
+- `[time_windows]` customization works, cycle order matches list order, "All" always appended last
+- All `[keys]` rebindings work; multiple keys per action supported via `[]string`
+- All `[display]` icons and colors work for the 6 attention signals + header color
+- Backward-compatible `Classify()` wrapper alongside new `ClassifyWith()`
+- `"space"` alias normalized to `" "` in key config
+- Validation: refresh >= 10s, ratio 0.2-0.8, no empty required bindings (quit)
+
+### Must NOT Have (Guardrails)
+- No config hot-reload - restart required for config changes
+- No config subcommands (`--dump-config`, `--validate-config`, `--generate-config`)
+- No environment variable overrides (only `--config` flag and TOML file)
+- No per-project config - one global config file
+- FilterPreset is NOT configurable (only its default selection via `[defaults].filter`)
+- No new dependencies beyond `github.com/BurntSushi/toml`
+- Store layer (`internal/store/`) has ZERO file modifications
+- `internal/config` must NOT import any package from this module (`internal/domain`, `internal/ui`, `internal/store`, `internal/app`) - it defines its own types (e.g., `config.TimeWindowOption{Label, Hours}`) and conversion to domain types happens in `internal/ui/app.go` (which imports both `config` and `domain`). Attention threshold conversion happens in `main.go` (which imports `config` and `attention`).
+- Aggregator struct and `NewAggregator()` 6-interface signature remain UNCHANGED. Add a separate `NewAggregatorWithClassifier()` for config-driven classification.. Add a separate `NewAggregatorWithClassifier(classify, repos...)` constructor for config-driven classification. Do NOT modify the existing `NewAggregator()` signature.
+- Do NOT make todo priority colors or diff colors configurable. The `ColorHeader` accent color (`#7D56F4`) IS configurable and applies everywhere it's currently used: app header bar, active preset highlight, pane border accent, and `sectionHeaderStyle` in styles.go. These all share one color via `ColorHeader`, not separate config fields.
+- No hex color validator - let lipgloss handle invalid colors (falls back to terminal default)
+- Do NOT change the `attention.Classify()` function signature - add ClassifyWith() alongside it
+
+---
+
+## Verification Strategy
+
+> **ZERO HUMAN INTERVENTION** - ALL verification is agent-executed. No exceptions.
+
+### Test Decision
+- **Infrastructure exists**: YES (11 test files, testify/assert, go test)
+- **Automated tests**: TDD - write tests first for config package, tests alongside for UI wiring
+- **Framework**: `go test` with `github.com/stretchr/testify/assert`
+- **Pattern**: Follow existing style - `fixedNow()` helper for deterministic time, table-driven tests, testify/assert
+
+### QA Policy
+Every task MUST include agent-executed QA scenarios.
+Evidence saved to `.sisyphus/evidence/task-{N}-{scenario-slug}.{ext}`.
+
+- **Config package**: Use Bash (`go test -run TestName ./internal/config/`) for TDD red-green cycles
+- **Attention/Filter**: Use Bash (`go test ./internal/attention/ ./internal/filter/`)
+- **UI wiring**: Use Bash (`go build ./...` + `go test ./...`) for compilation and regression checks
+- **Integration**: Use interactive_bash (tmux) to launch the TUI with and without config files
+
+---
+
+## Execution Strategy
+
+### Parallel Execution Waves
+
+```
+Wave 1 (Start Immediately - foundation):
+├── Task 1: Add BurntSushi/toml dependency [quick]
+├── Task 2: Config package - struct, defaults, loading, validation [deep]
+├── Task 3: Config package - KeyMap struct and Matches helper [quick]
+└── Task 4: Attention - Thresholds struct + ClassifyWith [quick]
+
+Wave 2 (After Wave 1 - type transitions + wiring prep):
+├── Task 5: TimeWindow enum replacement (domain + filter + filterbar) [deep]
+├── Task 6: Display config helpers (styles.go) [quick]
+└── (Task 4 has no wave-2 dependents - just needs to be done before Task 12)
+
+Wave 3 (After Wave 2 - UI wiring, MAX PARALLEL):
+├── Task 7: Wire config into FilterBarModel [unspecified-high]
+├── Task 8: Wire config into SessionListModel [quick]
+├── Task 9: Wire config into LayoutModel [quick]
+├── Task 10: Wire config into AppModel (keys, refresh, footer) [unspecified-high]
+└── Task 11: Wire display config into filter bar legend [quick]
+
+Wave 4 (After Wave 3 - integration):
+└── Task 12: main.go - flag, load, bridge types, pass through [deep]
+
+Wave FINAL (After ALL tasks - 4 parallel reviews, then user okay):
+├── Task F1: Plan compliance audit (oracle)
+├── Task F2: Code quality review (unspecified-high)
+├── Task F3: Real manual QA (unspecified-high)
+└── Task F4: Scope fidelity check (deep)
+-> Present results -> Get explicit user okay
+
+Critical Path: Task 1 -> Task 2 -> Task 5 -> Tasks 7-11 -> Task 12 -> F1-F4 -> user okay
+Parallel Speedup: ~55% faster than sequential
+Max Concurrent: 5 (Wave 3)
+```
+
+### Dependency Matrix
+
+| Task | Depends On | Blocks | Wave |
+|------|-----------|--------|------|
+| 1 | - | 2, 3 | 1 |
+| 2 | 1 | 5, 6, 7, 8, 9, 10, 11, 12 | 1 |
+| 3 | 1 | 7, 8, 9, 10, 12 | 1 |
+| 4 | - | 12 | 1 |
+| 5 | 2 | 7, 10, 11, 12 | 2 |
+| 6 | 2 | 7, 8, 11, 12 | 2 |
+| 7 | 2, 3, 5, 6 | 12 | 3 |
+| 8 | 2, 3, 6 | 12 | 3 |
+| 9 | 2, 3, 5 | 12 | 3 |
+| 10 | 2, 3, 5 | 12 | 3 |
+| 11 | 2, 5, 6 | 12 | 3 |
+| 12 | ALL 1-11 | F1-F4 | 4 |
+| F1-F4 | 12 | user okay | FINAL |
+
+### Agent Dispatch Summary
+
+- **Wave 1**: 4 tasks - T1 `quick`, T2 `deep`, T3 `quick`, T4 `quick`
+- **Wave 2**: 2 tasks - T5 `deep`, T6 `quick`
+- **Wave 3**: 5 tasks - T7 `unspecified-high`, T8 `quick`, T9 `quick`, T10 `unspecified-high`, T11 `quick`
+- **Wave 4**: 1 task - T12 `deep`
+- **FINAL**: 4 tasks - F1 `oracle`, F2 `unspecified-high`, F3 `unspecified-high`, F4 `deep`
+
+---
+
+## TODOs
+
+- [x] 1. Add BurntSushi/toml dependency
+
+  **What to do**:
+  - Run `go get github.com/BurntSushi/toml` in the project root
+  - Verify `go.mod` and `go.sum` are updated
+  - Verify `go build ./...` still compiles
+
+  **Must NOT do**:
+  - Do not add any other dependencies
+  - Do not modify any source files
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Single command, trivial verification
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 2, 3, 4)
+  - **Blocks**: Tasks 2, 3
+  - **Blocked By**: None
+
+  **References**:
+
+  **Pattern References**:
+  - `go.mod` - current module declaration and dependencies
+
+  **External References**:
+  - https://pkg.go.dev/github.com/BurntSushi/toml - TOML library for Go
+
+  **Acceptance Criteria**:
+
+  ```
+  Scenario: BurntSushi/toml dependency added successfully
+    Tool: Bash
+    Preconditions: Working directory is /Users/joey/Sites/opencode-dashboard
+    Steps:
+      1. Run: go get github.com/BurntSushi/toml
+      2. Run: grep 'BurntSushi/toml' go.mod
+      3. Run: go build ./...
+    Expected Result: grep finds "github.com/BurntSushi/toml" in go.mod; build succeeds with exit code 0
+    Failure Indicators: grep returns empty; build fails
+    Evidence: .sisyphus/evidence/task-1-toml-dep.txt
+  ```
+
+  **Commit**: YES
+  - Message: `chore: add BurntSushi/toml dependency`
+  - Files: `go.mod`, `go.sum`
+  - Pre-commit: `go build ./...`
+
+- [x] 2. Config package - struct, defaults, loading, validation (TDD)
+
+  **What to do**:
+  - Create `internal/config/config.go` with the full Config struct hierarchy:
+    ```go
+    type Config struct {
+        Defaults    DefaultsConfig    `toml:"defaults"`
+        Thresholds  ThresholdsConfig  `toml:"thresholds"`
+        TimeWindows TimeWindowsConfig `toml:"time_windows"`
+        Keys        KeysConfig        `toml:"keys"`
+        Display     DisplayConfig     `toml:"display"`
+    }
+    ```
+  - **DefaultsConfig**: `Filter string` (default `"needs_attention"`), `TimeWindow string` (default `"3d"`), `RefreshInterval int` (default `30`, minimum 10), `ListWidthRatio float64` (default `0.5`, range 0.2-0.8)
+  - **ThresholdsConfig**: `ActiveNowMinutes int` (default `5`), `NeedsResponseHours int` (default `24`), `StaleWorkDays int` (default `7`)
+  - **TimeWindowsConfig**: `Options []TimeWindowOption` where `TimeWindowOption{Label string, Hours int}`. Default: `[{1d,24}, {3d,72}, {7d,168}]`
+  - **KeysConfig**: One `[]string` field per action with TOML tags. Defaults must EXACTLY match current hardcoded strings:
+    - `Up: ["k", "up"]`, `Down: ["j", "down"]`, `PaneLeft: ["h"]`, `PaneRight: ["l", "right"]`
+    - `TreeNav: ["left"]`, `Collapse: [" "]`, `CycleFilter: ["tab"]`, `CycleTime: ["t"]`
+    - `Search: ["/"]`, `Refresh: ["r"]`, `Launch: ["enter"]`, `Quit: ["q", "ctrl+c"]`
+  - **DisplayConfig**: Icon fields (`IconError string` default `"!"`, `IconWaiting` `"@"`, `IconActive` `"*"`, `IconReply` `"?"`, `IconStale` `"~"`, `IconTodos` `"."`) and color fields (`ColorError` `"#FF0000"`, `ColorWaiting` `"#FF44FF"`, `ColorActive` `"#00FF00"`, `ColorReply` `"#FFFF00"`, `ColorStale` `"#FFA500"`, `ColorTodos` `"#0088FF"`, `ColorSelected` `""`, `ColorHeader` `"#7D56F4"`)
+  - Implement `Default() Config` returning all built-in defaults
+  - Implement `Load(explicitPath string) (Config, error)`:
+    - If `explicitPath != ""`: try to open that path. If not found, return error (NOT silent fallback). If found, decode.
+    - If `explicitPath == ""`: resolve path via `ResolvePath()`. If not found, return `Default(), nil` (silent fallback).
+    - Decode TOML onto a pre-filled `Default()` struct (missing fields keep defaults).
+    - After decode, check `MetaData.Undecoded()` - if any unknown keys, print warning to stderr (NOT error).
+    - Call `Validate()` on the result. Return error if invalid.
+  - Implement `ResolvePath() string`:
+    - Check `$XDG_CONFIG_HOME/opencode-dashboard/config.toml`
+    - Fall back to `~/.config/opencode-dashboard/config.toml`
+    - Return empty string if neither exists
+  - Implement `Validate(cfg Config) error`:
+    - `RefreshInterval >= 10`
+    - `ListWidthRatio >= 0.2 && <= 0.8`
+    - `ActiveNowMinutes > 0`, `NeedsResponseHours > 0`, `StaleWorkDays > 0`
+    - Quit binding must not be empty
+    - Return descriptive error with field name
+  - Create `internal/config/config_test.go` with TDD tests (RED first, then GREEN):
+    - `TestDefault_AllFieldsPopulated` - verify every field matches current hardcoded values
+    - `TestDefault_GoldenValues` - exact comparison: RefreshInterval==30, ActiveNowMinutes==5, etc.
+    - `TestLoad_MissingFile_ReturnsDefaults` - empty path, no file on disk = Default(), nil
+    - `TestLoad_ExplicitPathMissing_ReturnsError` - explicit path that doesn't exist = non-nil error
+    - `TestLoad_EmptyFile_ReturnsDefaults` - file exists but empty = all defaults preserved
+    - `TestLoad_PartialConfig_MergesDefaults` - only `[keys]` section, everything else defaults
+    - `TestLoad_FullConfig` - all sections populated, verify each field
+    - `TestLoad_ParseError_ReturnsError` - malformed TOML = non-nil error
+    - `TestLoad_SliceReplacement` - user-defined time windows REPLACE defaults (not merge)
+    - `TestValidate_RefreshTooLow` - value 5 rejected
+    - `TestValidate_RatioOutOfRange` - 0.0 and 1.0 rejected
+    - `TestValidate_NegativeThresholds` - 0 or negative rejected
+    - `TestValidate_EmptyQuitBinding` - empty quit = rejected
+    - `TestResolvePath_XDGOverride` - respects $XDG_CONFIG_HOME
+    - Use `t.TempDir()` for test config files (cleaned up automatically)
+
+  **Must NOT do**:
+  - Do not import any UI, store, or app package (`internal/ui`, `internal/store`, `internal/app`). Importing `internal/domain` is NOT allowed either - config defines its own `TimeWindowOption` struct (with `Label string` and `Hours int`). Conversion to `domain.TimeWindowOption` (with `Duration`) happens in `main.go`, not in the config package.
+  - Only import stdlib (`time`, `os`, `path/filepath`, `fmt`, `strings`, `errors`) + `github.com/BurntSushi/toml` + `github.com/stretchr/testify/assert` (test only)
+  - Do not add config hot-reload, file watching, or environment variable overrides
+  - Do not add a `--dump-config` or `--validate-config` subcommand
+  - Do not use `os.UserConfigDir()` - use `$XDG_CONFIG_HOME` with `~/.config` fallback per the issue spec
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+    - Reason: Core package with TDD, many test cases, validation logic, TOML integration - needs careful design
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES (with Tasks 3, 4 after Task 1 completes)
+  - **Parallel Group**: Wave 1
+  - **Blocks**: Tasks 5, 6, 7, 8, 9, 10, 11, 12
+  - **Blocked By**: Task 1
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/attention/classifier.go:9-12` - Current hardcoded threshold values that become Config defaults: `ActiveNowWindow = 5 * time.Minute`, `NeedsResponseWindow = 24 * time.Hour`, `StaleThreshold = 7 * 24 * time.Hour`
+  - `internal/ui/filterbar.go:38-40` - Current default filter preset (`FilterNeedsAttention`) and time window (`TimeWindow3Days`) that become Config.Defaults
+  - `internal/ui/app.go:76` - Current hardcoded refresh interval `30*time.Second` that becomes Config.Defaults.RefreshInterval
+  - `internal/ui/layout.go:227-233` - Current hardcoded 50/50 pane split (`m.width / 2`) that becomes Config.Defaults.ListWidthRatio
+  - `internal/ui/styles.go:16-52` - Current hardcoded icons and colors for all 6 attention signals that become Config.Display fields
+  - `internal/ui/app.go:18-21` - Header color `#7D56F4` that becomes Config.Display.ColorHeader
+  - `internal/ui/layout.go:96,102,116,123,135-148` - All hardcoded key strings in layout that become Config.Keys defaults
+  - `internal/ui/sessionlist.go:108-138` - All hardcoded key strings in session list
+  - `internal/ui/app.go:172-181` - All hardcoded key strings in app (quit, refresh)
+  - `internal/ui/filterbar.go:89-99` - All hardcoded key strings in filter bar (tab, t, /)
+  - `internal/attention/classifier_test.go:149-151` - Test pattern using `fixedNow()` helper and `testify/assert`
+
+  **External References**:
+  - https://pkg.go.dev/github.com/BurntSushi/toml - TOML decoding API, especially `toml.Decode()`, `toml.DecodeFile()`, `MetaData.Undecoded()`
+
+  **WHY Each Reference Matters**:
+  - The threshold/key/icon/color values from the source files are the EXACT defaults that `Default()` must return
+  - The classifier test pattern shows the project's testing conventions to follow
+  - The TOML docs explain decode-onto-struct semantics and MetaData.Undecoded() for unknown key warnings
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: Golden defaults match current hardcoded values
+    Tool: Bash
+    Preconditions: internal/config/ package created with config.go and config_test.go
+    Steps:
+      1. Run: go test -v -run TestDefault_GoldenValues ./internal/config/
+    Expected Result: Test passes. Default().Thresholds.ActiveNowMinutes == 5, NeedsResponseHours == 24, StaleWorkDays == 7. Default().Defaults.RefreshInterval == 30. Default().Display.IconError == "!". All fields verified.
+    Failure Indicators: Any assertion failure showing default != current hardcoded value
+    Evidence: .sisyphus/evidence/task-2-golden-defaults.txt
+
+  Scenario: Missing config file returns defaults silently
+    Tool: Bash
+    Preconditions: No config file at resolved path
+    Steps:
+      1. Run: go test -v -run TestLoad_MissingFile_ReturnsDefaults ./internal/config/
+    Expected Result: Load("") returns (Default(), nil) - no error, all defaults
+    Failure Indicators: Non-nil error returned, or config differs from Default()
+    Evidence: .sisyphus/evidence/task-2-missing-file.txt
+
+  Scenario: Explicit path missing returns error
+    Tool: Bash
+    Preconditions: None
+    Steps:
+      1. Run: go test -v -run TestLoad_ExplicitPathMissing_ReturnsError ./internal/config/
+    Expected Result: Load("/nonexistent/path.toml") returns non-nil error
+    Failure Indicators: Error is nil (silent fallback when explicit path given)
+    Evidence: .sisyphus/evidence/task-2-explicit-missing.txt
+
+  Scenario: Partial config merges onto defaults
+    Tool: Bash
+    Preconditions: None
+    Steps:
+      1. Run: go test -v -run TestLoad_PartialConfig_MergesDefaults ./internal/config/
+    Expected Result: Only specified fields changed, all others equal Default()
+    Failure Indicators: Unspecified fields don't match Default()
+    Evidence: .sisyphus/evidence/task-2-partial-config.txt
+
+  Scenario: Invalid TOML returns parse error
+    Tool: Bash
+    Preconditions: None
+    Steps:
+      1. Run: go test -v -run TestLoad_ParseError_ReturnsError ./internal/config/
+    Expected Result: Non-nil error containing TOML parse information
+    Failure Indicators: Error is nil or doesn't mention parse failure
+    Evidence: .sisyphus/evidence/task-2-parse-error.txt
+
+  Scenario: Validation catches invalid values
+    Tool: Bash
+    Preconditions: None
+    Steps:
+      1. Run: go test -v -run TestValidate ./internal/config/
+    Expected Result: All validation tests pass (refresh too low, ratio out of range, negative thresholds, empty quit)
+    Failure Indicators: Any validation test fails
+    Evidence: .sisyphus/evidence/task-2-validation.txt
+
+  Scenario: Full test suite passes
+    Tool: Bash
+    Preconditions: All config tests written
+    Steps:
+      1. Run: go test -v ./internal/config/
+    Expected Result: All tests pass, zero failures
+    Failure Indicators: Any test failure
+    Evidence: .sisyphus/evidence/task-2-full-suite.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feat(config): add config package with TOML loading and validation`
+  - Files: `internal/config/config.go`, `internal/config/config_test.go`
+  - Pre-commit: `go test ./internal/config/`
+
+- [x] 3. Config package - KeyMap struct and Matches helper (TDD)
+
+  **What to do**:
+  - Create `internal/config/keys.go` with:
+    ```go
+    // KeyMap maps actions to key binding strings.
+    // Key strings match bubbletea's tea.KeyMsg.String() output.
+    // Examples: "ctrl+c", "tab", "enter", "q", " " (space).
+    // See: https://pkg.go.dev/github.com/charmbracelet/bubbletea#KeyMsg
+    type KeyMap struct {
+        Up          []string
+        Down        []string
+        PaneLeft    []string
+        PaneRight   []string
+        TreeNav     []string
+        Collapse    []string
+        CycleFilter []string
+        CycleTime   []string
+        Search      []string
+        Refresh     []string
+        Launch      []string
+        Quit        []string
+    }
+    ```
+  - Implement `Matches(keyStr string, bindings []string) bool` as a **standalone function** (not method on KeyMap). Does exact string comparison with one normalization: if `bindings` contains `"space"`, it also matches `" "`.
+  - Implement `NormalizeKey(key string) string` that converts `"space"` -> `" "` (used during config loading to normalize all binding values)
+  - Implement `DefaultKeyMap() KeyMap` returning the exact current hardcoded bindings
+  - Create `internal/config/keys_test.go`:
+    - `TestMatches_SingleKey` - `Matches("q", []string{"q"})` == true
+    - `TestMatches_MultipleKeys` - `Matches("ctrl+c", []string{"q", "ctrl+c"})` == true
+    - `TestMatches_NoMatch` - `Matches("x", []string{"q", "ctrl+c"})` == false
+    - `TestMatches_EmptyBindings` - `Matches("q", []string{})` == false
+    - `TestMatches_SpaceAlias` - `Matches(" ", []string{"space"})` == true
+    - `TestMatches_SpaceAliasReverse` - `Matches(" ", []string{" "})` == true
+    - `TestNormalizeKey` - `NormalizeKey("space")` == `" "`
+    - `TestDefaultKeyMap_MatchesHardcoded` - verify every default binding matches the current hardcoded strings from the UI files
+
+  **Must NOT do**:
+  - Do not import bubbletea or any UI package
+  - Do not add complex normalization beyond the "space" alias
+  - Keep Matches as a standalone function, not a method
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Small focused file with straightforward matching logic
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES (with Tasks 2, 4 after Task 1)
+  - **Parallel Group**: Wave 1
+  - **Blocks**: Tasks 7, 8, 9, 10, 12
+  - **Blocked By**: Task 1
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/ui/layout.go:96` - `msg.String() == "tab"` - CycleFilter default
+  - `internal/ui/layout.go:102` - `msg.String() == "t"` - CycleTime default
+  - `internal/ui/layout.go:116` - `msg.String() == "/"` - Search default
+  - `internal/ui/layout.go:123` - `msg.String() == "left"` - TreeNav default
+  - `internal/ui/layout.go:136-141` - `"h"`, `"l"`, `"right"` - Pane switch defaults
+  - `internal/ui/layout.go:142` - `"enter"` - Launch default
+  - `internal/ui/sessionlist.go:109` - `"j", "down"` - Down defaults
+  - `internal/ui/sessionlist.go:113` - `"k", "up"` - Up defaults
+  - `internal/ui/sessionlist.go:117` - `" "` (space) - Collapse default
+  - `internal/ui/sessionlist.go:124` - `"left"` - TreeNav in list context
+  - `internal/ui/app.go:172` - `"ctrl+c"` - Quit default
+  - `internal/ui/app.go:175` - `"q"` - Quit default
+  - `internal/ui/app.go:178` - `"r"` - Refresh default
+  - `internal/ui/filterbar.go:90-93` - `"tab"`, `"t"` - CycleFilter/CycleTime in filterbar
+
+  **WHY Each Reference Matters**:
+  - These are the EXACT strings that DefaultKeyMap() must produce. Getting any one wrong breaks backward compatibility.
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: Key matching works correctly
+    Tool: Bash
+    Preconditions: internal/config/keys.go and keys_test.go created
+    Steps:
+      1. Run: go test -v -run TestMatches ./internal/config/
+    Expected Result: All Matches tests pass - single key, multi-key, no match, empty, space alias
+    Failure Indicators: Any test failure
+    Evidence: .sisyphus/evidence/task-3-matches.txt
+
+  Scenario: Default KeyMap matches hardcoded strings
+    Tool: Bash
+    Preconditions: keys.go with DefaultKeyMap() implemented
+    Steps:
+      1. Run: go test -v -run TestDefaultKeyMap_MatchesHardcoded ./internal/config/
+    Expected Result: Every default binding verified against current hardcoded values
+    Failure Indicators: Any binding mismatch
+    Evidence: .sisyphus/evidence/task-3-default-keymap.txt
+
+  Scenario: Space normalization works
+    Tool: Bash
+    Preconditions: None
+    Steps:
+      1. Run: go test -v -run TestNormalizeKey ./internal/config/
+      2. Run: go test -v -run TestMatches_SpaceAlias ./internal/config/
+    Expected Result: "space" normalizes to " "; Matches(" ", ["space"]) == true
+    Failure Indicators: Normalization fails
+    Evidence: .sisyphus/evidence/task-3-space-normalize.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feat(config): add KeyMap struct with key matching`
+  - Files: `internal/config/keys.go`, `internal/config/keys_test.go`
+  - Pre-commit: `go test ./internal/config/`
+
+- [x] 4. Attention - Thresholds struct + ClassifyWith (TDD)
+
+  **What to do**:
+  - In `internal/attention/classifier.go`, add:
+    ```go
+    type Thresholds struct {
+        ActiveNowWindow     time.Duration
+        NeedsResponseWindow time.Duration
+        StaleThreshold      time.Duration
+    }
+
+    func DefaultThresholds() Thresholds {
+        return Thresholds{
+            ActiveNowWindow:     5 * time.Minute,
+            NeedsResponseWindow: 24 * time.Hour,
+            StaleThreshold:      7 * 24 * time.Hour,
+        }
+    }
+
+    func ClassifyWith(view domain.SessionView, now time.Time, t Thresholds) domain.AttentionSignal {
+        // Same logic as Classify but using t.ActiveNowWindow, t.NeedsResponseWindow, t.StaleThreshold
+    }
+    ```
+  - Refactor existing `Classify()` to call `ClassifyWith(view, now, DefaultThresholds())` - this is a one-line wrapper
+  - Keep the existing package-level `const` values (they're still referenced by existing tests via `ActiveNowWindow`, `NeedsResponseWindow`, `StaleThreshold`)
+  - In `internal/attention/classifier_test.go`, add new tests (DO NOT modify existing tests):
+    - `TestClassifyWith_CustomActiveWindow` - 10-minute active window: session at 7 minutes is ActiveNow (would be None with default 5min)
+    - `TestClassifyWith_CustomNeedsResponseWindow` - 48-hour response window: session at 30 hours with assistant last message is NeedsResponse (would be None with default 24h)
+    - `TestClassifyWith_CustomStaleThreshold` - 3-day stale: session at 4 days with pending todos is StaleWork (would be PendingTodos with default 7d)
+    - `TestClassifyWith_DefaultThresholdsMatchClassify` - verify ClassifyWith with DefaultThresholds() produces identical results to Classify() for all existing test cases
+
+  **Must NOT do**:
+  - Do NOT change the signature of `Classify(view domain.SessionView, now time.Time) domain.AttentionSignal`
+  - Do NOT modify ANY existing test function
+  - Do NOT remove the package-level const values (existing tests reference them)
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Small addition to existing file with clear pattern, straightforward tests
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES (with Tasks 2, 3 - no dependency on Task 1)
+  - **Parallel Group**: Wave 1
+  - **Blocks**: Task 12
+  - **Blocked By**: None
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/attention/classifier.go:9-12` - Current const values that become DefaultThresholds() return values
+  - `internal/attention/classifier.go:15-47` - Current Classify() logic that ClassifyWith() replicates with parameterized thresholds
+  - `internal/attention/classifier_test.go:11-151` - All 14 existing tests showing the testing pattern, fixedNow() helper, testify/assert usage
+
+  **WHY Each Reference Matters**:
+  - classifier.go contains the exact logic to parameterize - the three const references (lines 30, 34, 39) become threshold struct field references
+  - classifier_test.go shows the exact test style to follow and the exact values that must remain unchanged for backward compatibility
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: All existing classifier tests still pass unchanged
+    Tool: Bash
+    Preconditions: ClassifyWith() added, Classify() refactored as wrapper
+    Steps:
+      1. Run: go test -v -run "TestClassify_" ./internal/attention/
+    Expected Result: All 14 existing TestClassify_* tests pass with zero modifications
+    Failure Indicators: Any existing test fails
+    Evidence: .sisyphus/evidence/task-4-existing-tests.txt
+
+  Scenario: Custom thresholds produce different classifications
+    Tool: Bash
+    Preconditions: ClassifyWith tests written
+    Steps:
+      1. Run: go test -v -run "TestClassifyWith_" ./internal/attention/
+    Expected Result: All ClassifyWith tests pass - custom windows/thresholds change classification outcomes
+    Failure Indicators: Custom thresholds produce same result as defaults (not testing correctly)
+    Evidence: .sisyphus/evidence/task-4-custom-thresholds.txt
+
+  Scenario: DefaultThresholds matches Classify
+    Tool: Bash
+    Preconditions: None
+    Steps:
+      1. Run: go test -v -run TestClassifyWith_DefaultThresholdsMatchClassify ./internal/attention/
+    Expected Result: ClassifyWith(view, now, DefaultThresholds()) == Classify(view, now) for all test cases
+    Failure Indicators: Any divergence between Classify and ClassifyWith+DefaultThresholds
+    Evidence: .sisyphus/evidence/task-4-default-match.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feat(attention): add configurable thresholds via ClassifyWith`
+  - Files: `internal/attention/classifier.go`, `internal/attention/classifier_test.go`
+  - Pre-commit: `go test ./internal/attention/`
+
+- [ ] 5. Replace TimeWindow enum with config-driven TimeWindowOption (ATOMIC)
+
+  **What to do**:
+  This is an ATOMIC change across 4 files. All changes must happen in a single commit because the type is shared.
+
+  **Step A - `internal/domain/types.go`**:
+  - REMOVE the `TimeWindow` type, its iota constants (`TimeWindowAll`, `TimeWindow1Day`, `TimeWindow3Days`, `TimeWindow7Days`), and its `String()` and `Duration()` methods (lines 130-163)
+  - ADD:
+    ```go
+    type TimeWindowOption struct {
+        Label    string
+        Duration time.Duration // 0 means "all" (no time filtering)
+    }
+    ```
+
+  **Step B - `internal/filter/filter.go`**:
+  - Change `Filter` struct field from `Window domain.TimeWindow` to `Window time.Duration` (the resolved duration, not the option struct)
+  - Update `matchesWindow(s domain.SessionView, w domain.TimeWindow)` to `matchesWindow(s domain.SessionView, d time.Duration, now time.Time)`:
+    ```go
+    func matchesWindow(s domain.SessionView, d time.Duration, now time.Time) bool {
+        if d == 0 {
+            return true // "all" - no filtering
+        }
+        return s.TimeUpdated.After(now.Add(-d))
+    }
+    ```
+  - Update `Apply()` to pass `f.Window` and `time.Now()` (or accept `now` parameter for testability - prefer adding `now` parameter)
+  - Actually, update `Apply` signature to `Apply(sessions []domain.SessionView, f Filter, now time.Time)` for testability. The caller (app.go `applyFilter`) passes `time.Now()`.
+
+  **Step C - `internal/filter/filter_test.go`**:
+  - Update all test calls to use `time.Duration` for the Window field instead of the old enum
+  - Use `0` for "all", `24 * time.Hour` for 1-day, etc.
+  - Add time window filter tests (currently missing):
+    - `TestApply_TimeWindow_All` - duration 0 matches everything
+    - `TestApply_TimeWindow_1Day` - filters sessions older than 24h
+    - `TestApply_TimeWindow_Boundary` - session exactly at window boundary
+
+  **Step D - `internal/ui/filterbar.go`**:
+  - Add fields to FilterBarModel: `windowOptions []domain.TimeWindowOption`, `windowIdx int`
+  - Replace `window domain.TimeWindow` field with the index-based approach
+  - Update `NewFilterBar()` to accept `windowOptions []domain.TimeWindowOption` and `defaultWindowIdx int`
+  - Replace `nextWindow()` function with index arithmetic: `m.windowIdx = (m.windowIdx + 1) % len(m.windowOptions)`
+  - Update `CurrentFilter()` to return `filter.Filter{Window: m.windowOptions[m.windowIdx].Duration, ...}`
+  - Update `View()` to display `m.windowOptions[m.windowIdx].Label` instead of calling `.String()` on enum
+
+  **Step E - `internal/ui/app.go`**:
+  - Update `applyFilter()` to pass `time.Now()` to `filter.Apply()`
+
+  **Step F - Conversion location: `internal/ui/app.go` (NOT in config or main.go)**:
+  - The config package defines its own `config.TimeWindowOption{Label string, Hours int}`. Conversion to `domain.TimeWindowOption{Label string, Duration time.Duration}` happens in `internal/ui/app.go` inside `NewAppWithConfig()` (Task 10), because app.go imports both `internal/config` and `internal/domain`.
+  - `app.go` iterates `cfg.TimeWindows.Options`, converts each `Hours` to `time.Duration`, appends the "All" sentinel `{Label: "All", Duration: 0}`, and passes the result down to `NewLayout()` which passes to `NewFilterBar()`.
+  - Default preset resolution (`cfg.Defaults.Filter` string -> `domain.FilterPreset`) and default window index resolution (`cfg.Defaults.TimeWindow` label -> index) also happen in `app.go`.
+
+  **Must NOT do**:
+  - Do not keep the old TimeWindow enum around "for compatibility" - clean removal
+  - Do not make FilterPreset configurable
+  - Do not change the Store layer
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+    - Reason: Atomic 6-file change with type system migration, needs careful coordination
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO (touches shared types, must land as one unit)
+  - **Parallel Group**: Wave 2 (after Task 2 completes)
+  - **Blocks**: Tasks 7, 10, 11, 12
+  - **Blocked By**: Task 2
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/domain/types.go:130-163` - TimeWindow enum, String(), Duration() methods TO BE REMOVED
+  - `internal/filter/filter.go:13-14` - `Filter.Window` field that changes type
+  - `internal/filter/filter.go:55-60` - `matchesWindow()` that changes signature and adds `now` parameter
+  - `internal/filter/filter.go:16` - `Apply()` call site that adds `now` parameter
+  - `internal/ui/filterbar.go:22-28` - FilterBarModel fields that change (window -> windowOptions + windowIdx)
+  - `internal/ui/filterbar.go:34-42` - `NewFilterBar()` constructor that gets new parameters
+  - `internal/ui/filterbar.go:51-57` - `CurrentFilter()` that returns Duration instead of enum
+  - `internal/ui/filterbar.go:93-94` - `nextWindow()` call that becomes index arithmetic
+  - `internal/ui/filterbar.go:136` - `View()` window label display
+  - `internal/ui/filterbar.go:182-193` - `nextWindow()` function TO BE REPLACED with index arithmetic
+  - `internal/ui/app.go:193-206` - `applyFilter()` that needs to pass `time.Now()` to `filter.Apply()`
+  - `internal/filter/filter_test.go` - All existing filter tests that need Window field type updates
+
+  **External References**:
+  - Issue TOML schema: `[time_windows] options = [{label = "1d", hours = 24}, ...]` - the cycle order follows list order; "all" always appended
+
+  **WHY Each Reference Matters**:
+  - domain/types.go is the type being removed - executor needs to see exactly what goes away
+  - filter.go/filter_test.go show what changes type from enum to duration
+  - filterbar.go shows all the places that used the enum for cycling/display
+  - app.go shows the Apply() call site that needs the new `now` parameter
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: Project compiles after atomic type change
+    Tool: Bash
+    Preconditions: All 4+ files modified atomically
+    Steps:
+      1. Run: go build ./...
+    Expected Result: Compilation succeeds with zero errors
+    Failure Indicators: Any compilation error (usually means a file was missed in the atomic change)
+    Evidence: .sisyphus/evidence/task-5-compiles.txt
+
+  Scenario: All existing filter tests pass (updated for new type)
+    Tool: Bash
+    Preconditions: filter_test.go updated with Duration instead of enum
+    Steps:
+      1. Run: go test -v ./internal/filter/
+    Expected Result: All existing tests pass + new time window tests pass
+    Failure Indicators: Any test failure
+    Evidence: .sisyphus/evidence/task-5-filter-tests.txt
+
+  Scenario: Time window cycling uses index arithmetic, not enum switch
+    Tool: Bash
+    Preconditions: FilterBarModel updated with windowOptions slice
+    Steps:
+      1. Run: go build ./...
+      2. Run: grep -c 'nextWindow' internal/ui/filterbar.go (expect 0 - function removed)
+      3. Run: grep -c 'windowIdx' internal/ui/filterbar.go (expect >= 2 - field used in cycling)
+      4. Run: grep -c 'TimeWindowAll\|TimeWindow1Day\|TimeWindow3Days\|TimeWindow7Days' internal/ui/filterbar.go (expect 0 - old enum gone)
+    Expected Result: Build passes; nextWindow function removed; windowIdx field present; no old enum references
+    Failure Indicators: nextWindow function still exists; old enum constants still referenced
+    Evidence: .sisyphus/evidence/task-5-cycling.txt
+
+  Scenario: Full test suite passes after type migration
+    Tool: Bash
+    Preconditions: All changes landed
+    Steps:
+      1. Run: go test ./...
+    Expected Result: ALL test files pass (existing + new)
+    Failure Indicators: Any test failure in any package
+    Evidence: .sisyphus/evidence/task-5-full-suite.txt
+  ```
+
+  **Commit**: YES
+  - Message: `refactor: replace TimeWindow enum with config-driven TimeWindowOption`
+  - Files: `internal/domain/types.go`, `internal/filter/filter.go`, `internal/filter/filter_test.go`, `internal/ui/filterbar.go`, `internal/ui/app.go`, `internal/config/config.go`
+  - Pre-commit: `go test ./...`
+
+- [ ] 6. Display config helpers in styles.go
+
+  **What to do**:
+  - In `internal/ui/styles.go`, modify `attentionIcon()` and `attentionIconPlain()` to accept a `config.DisplayConfig` parameter:
+    ```go
+    func attentionIcon(signal domain.AttentionSignal, d config.DisplayConfig) string {
+        icon, color := iconAndColor(signal, d)
+        if icon == "" {
+            return " "
+        }
+        return lipgloss.NewStyle().Foreground(lipgloss.Color(color)).Render(icon)
+    }
+
+    func attentionIconPlain(signal domain.AttentionSignal, d config.DisplayConfig) string {
+        icon, _ := iconAndColor(signal, d)
+        if icon == "" {
+            return " "
+        }
+        return icon
+    }
+    ```
+  - Add a private helper `iconAndColor(signal, d) (string, string)` that does the switch-case lookup against DisplayConfig fields
+  - Add methods to `config.DisplayConfig` for clean lookup:
+    ```go
+    func (d DisplayConfig) IconFor(signal domain.AttentionSignal) string
+    func (d DisplayConfig) ColorFor(signal domain.AttentionSignal) string
+    ```
+    Wait - DisplayConfig is in `internal/config` which must NOT import `internal/domain`. So these methods must live in the UI layer, not config. Use the private `iconAndColor()` helper in styles.go instead.
+  - Update all call sites of `attentionIcon()` and `attentionIconPlain()` to pass the DisplayConfig. These are in:
+    - `internal/ui/sessionlist.go:229,231` - renderSessionRow calls attentionIcon/attentionIconPlain
+  - This means SessionListModel needs to store a DisplayConfig (or receive it). For now, add a `display config.DisplayConfig` field to SessionListModel and pass it in the updated constructor (prepared for Task 8).
+  - Also update `sectionHeaderStyle` color to use `config.DisplayConfig.ColorHeader` (this is the shared accent color, not a separate section-specific config field)
+
+  **Must NOT do**:
+  - Do not add `domain` import to the `config` package
+  - Do not create IconFor/ColorFor methods on DisplayConfig in the config package
+  - Do not change todo priority colors or section styles beyond what's in DisplayConfig
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Small refactor of two existing functions plus adding a helper, pattern is clear
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES (with Task 5 in Wave 2)
+  - **Parallel Group**: Wave 2
+  - **Blocks**: Tasks 7, 8, 11, 12
+  - **Blocked By**: Task 2
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/ui/styles.go:16-52` - The two existing functions to modify (`attentionIcon`, `attentionIconPlain`) with their switch-case structure
+  - `internal/ui/styles.go:12-14` - `sectionHeaderStyle` with hardcoded `#7D56F4` color
+  - `internal/ui/sessionlist.go:229,231` - Call sites of attentionIcon/attentionIconPlain
+  - `internal/config/config.go` - DisplayConfig struct with all icon/color fields
+
+  **WHY Each Reference Matters**:
+  - styles.go contains the exact functions being parameterized - executor sees current structure
+  - sessionlist.go shows the call sites that need the extra parameter
+  - config.go provides the DisplayConfig type being passed in
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: Project compiles after display config wiring
+    Tool: Bash
+    Preconditions: styles.go updated, sessionlist.go call sites updated
+    Steps:
+      1. Run: go build ./...
+    Expected Result: Compilation succeeds
+    Failure Indicators: Missing parameter errors at call sites
+    Evidence: .sisyphus/evidence/task-6-compiles.txt
+
+  Scenario: All tests still pass
+    Tool: Bash
+    Preconditions: All changes made
+    Steps:
+      1. Run: go test ./...
+    Expected Result: All tests pass (no UI tests to break, but ensure no import cycles)
+    Failure Indicators: Import cycle errors or compilation failures
+    Evidence: .sisyphus/evidence/task-6-tests.txt
+  ```
+
+  **Commit**: YES
+  - Message: `refactor(ui): extract display config helpers in styles.go`
+  - Files: `internal/ui/styles.go`, `internal/ui/sessionlist.go`
+  - Pre-commit: `go build ./...`
+
+- [ ] 7. Wire config into FilterBarModel
+
+  **What to do**:
+  - Update `NewFilterBar()` signature to accept config parameters:
+    ```go
+    func NewFilterBar(keys config.KeyMap, display config.DisplayConfig, windowOptions []domain.TimeWindowOption, defaultPreset domain.FilterPreset, defaultWindowIdx int) FilterBarModel
+    ```
+  - Store `keys`, `display` on the FilterBarModel struct
+  - Replace all hardcoded key checks in `Update()` with `config.Matches(msg.String(), m.keys.XXX)`:
+    - `"tab"` -> `config.Matches(keyStr, m.keys.CycleFilter)`
+    - `"t"` -> `config.Matches(keyStr, m.keys.CycleTime)`
+    - `"/"` -> `config.Matches(keyStr, m.keys.Search)`
+    - `"esc"` and `"enter"` in search mode stay hardcoded (they're search-mode-specific, not configurable per issue schema)
+  - Update `View()` legend section to use display config for icon/color rendering:
+    ```go
+    // Current hardcoded:
+    color("#FF0000", "!") + " err"
+    // Becomes:
+    color(m.display.ColorError, m.display.IconError) + " err"
+    ```
+  - Default preset comes from `defaultPreset` parameter (parsed from `cfg.Defaults.Filter` string to `domain.FilterPreset` in the caller)
+  - Window options + default index already wired in Task 5
+
+  **Must NOT do**:
+  - Do not make FilterPreset options configurable (only the default selection)
+  - Do not make search-mode keys (esc, enter) configurable
+  - Do not change the search text behavior or filter logic
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+    - Reason: Multiple interrelated changes in one file, needs careful attention to not break filter bar behavior
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 3 (with Tasks 8, 9, 10, 11)
+  - **Blocks**: Task 12
+  - **Blocked By**: Tasks 2, 3, 5, 6
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/ui/filterbar.go:69-110` - Full Update() method with all key checks to replace
+  - `internal/ui/filterbar.go:112-169` - Full View() method with legend colors to parameterize
+  - `internal/ui/filterbar.go:34-42` - NewFilterBar() constructor to extend (already modified in Task 5 for windowOptions)
+  - `internal/ui/filterbar.go:21-28` - FilterBarModel struct to add keys/display fields
+  - `internal/config/keys.go` - KeyMap struct and Matches() function
+
+  **WHY Each Reference Matters**:
+  - filterbar.go Update() has the exact key checks to replace - executor sees current `msg.String() == "tab"` patterns
+  - filterbar.go View() has the exact legend colors to parameterize
+  - config/keys.go provides the Matches() function the new code calls
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: Filter bar compiles with config wiring
+    Tool: Bash
+    Preconditions: FilterBarModel updated with keys and display fields
+    Steps:
+      1. Run: go build ./...
+    Expected Result: Compilation succeeds
+    Failure Indicators: Missing field errors, import issues
+    Evidence: .sisyphus/evidence/task-7-compiles.txt
+
+  Scenario: No hardcoded key strings remain in filterbar.go Update() outside search mode
+    Tool: Bash
+    Preconditions: All key replacements done
+    Steps:
+      1. Run: grep -n 'msg.String() ==' internal/ui/filterbar.go (expect only lines inside searchMode block for "esc"/"enter")
+      2. Run: grep -c 'case "tab"\|== "tab"\|== "t"\|case "t"\|== "/"' internal/ui/filterbar.go (expect 0 - these should use config.Matches now)
+      3. Run: grep -c 'config.Matches\|Matches(' internal/ui/filterbar.go (expect >= 3 - one per configurable action: CycleFilter, CycleTime, Search)
+      4. Run: go build ./...
+    Expected Result: msg.String()== appears only for esc/enter in search mode; config.Matches used for tab/t/slash; build succeeds
+    Failure Indicators: "tab", "t", "/" appear in switch cases outside search mode
+    Evidence: .sisyphus/evidence/task-7-no-hardcoded-keys.txt
+
+  Scenario: Full test suite passes
+    Tool: Bash
+    Preconditions: All changes made
+    Steps:
+      1. Run: go test ./...
+    Expected Result: All tests pass
+    Failure Indicators: Any test failure
+    Evidence: .sisyphus/evidence/task-7-tests.txt
+  ```
+
+  **Commit**: YES (groups with Tasks 8, 9, 10, 11 - one commit per file is fine, or group Wave 3)
+  - Message: `feat(ui): wire config into FilterBarModel`
+  - Files: `internal/ui/filterbar.go`
+  - Pre-commit: `go build ./...`
+
+- [ ] 8. Wire config into SessionListModel
+
+  **What to do**:
+  - Update `NewSessionList()` to accept KeyMap and DisplayConfig:
+    ```go
+    func NewSessionList(groups []domain.ProjectGroup, keys config.KeyMap, display config.DisplayConfig) SessionListModel
+    ```
+  - Store `keys` and `display` on SessionListModel struct
+  - Replace all hardcoded key checks in `Update()` with `config.Matches()`:
+    - `"j", "down"` -> `config.Matches(keyStr, m.keys.Down)`
+    - `"k", "up"` -> `config.Matches(keyStr, m.keys.Up)`
+    - `" "` (space) -> `config.Matches(keyStr, m.keys.Collapse)`
+    - `"left"` -> `config.Matches(keyStr, m.keys.TreeNav)`
+  - The switch statement in Update() changes from string-matching cases to if/else-if with Matches() calls
+  - Pass display config to `attentionIcon()` and `attentionIconPlain()` calls in `renderSessionRow()` (already prepared by Task 6)
+
+  **Must NOT do**:
+  - Do not change the scrolling, cursor, or collapse behavior
+  - Do not modify buildVisibleRows() logic
+  - Do not change rendering layout or formatting
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Straightforward key replacement, small number of call sites
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 3
+  - **Blocks**: Task 12
+  - **Blocked By**: Tasks 2, 3, 6
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/ui/sessionlist.go:104-141` - Full Update() method with all key checks to replace
+  - `internal/ui/sessionlist.go:37-43` - NewSessionList() constructor to extend
+  - `internal/ui/sessionlist.go:27-34` - SessionListModel struct to add keys/display fields
+  - `internal/ui/sessionlist.go:226-278` - renderSessionRow() that calls attentionIcon/attentionIconPlain with display param
+
+  **WHY Each Reference Matters**:
+  - sessionlist.go Update() has the exact switch cases to replace with config.Matches()
+  - Constructor and struct show where new fields go
+  - renderSessionRow shows where DisplayConfig flows to icon rendering
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: Session list compiles with config wiring
+    Tool: Bash
+    Preconditions: SessionListModel updated
+    Steps:
+      1. Run: go build ./...
+    Expected Result: Compilation succeeds
+    Failure Indicators: Missing parameter errors
+    Evidence: .sisyphus/evidence/task-8-compiles.txt
+
+  Scenario: No hardcoded key strings remain in sessionlist.go Update()
+    Tool: Bash
+    Preconditions: All key replacements done
+    Steps:
+      1. Run: grep -n 'case "' internal/ui/sessionlist.go (expect 0 - no string-literal case clauses in Update)
+      2. Run: grep -c 'config.Matches\|Matches(' internal/ui/sessionlist.go (expect >= 4 - down, up, collapse, tree-nav)
+      3. Run: grep -c 'msg.String()' internal/ui/sessionlist.go (expect 0 or only inside Matches calls)
+      4. Run: go build ./...
+    Expected Result: Zero hardcoded key strings in switch cases; config.Matches used for all 4 actions; build succeeds
+    Failure Indicators: String literal case clauses like case "j" still present
+    Evidence: .sisyphus/evidence/task-8-no-hardcoded-keys.txt
+
+  Scenario: Full test suite passes
+    Tool: Bash
+    Preconditions: All changes made
+    Steps:
+      1. Run: go test ./...
+    Expected Result: All tests pass
+    Failure Indicators: Any test failure
+    Evidence: .sisyphus/evidence/task-8-tests.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feat(ui): wire config into SessionListModel`
+  - Files: `internal/ui/sessionlist.go`
+  - Pre-commit: `go build ./...`
+
+- [ ] 9. Wire config into LayoutModel
+
+  **What to do**:
+  - Update `NewLayout()` to accept all config needed by itself and its children:
+    ```go
+    func NewLayout(groups []domain.ProjectGroup, keys config.KeyMap, display config.DisplayConfig, listWidthRatio float64, windowOptions []domain.TimeWindowOption, defaultPreset domain.FilterPreset, defaultWindowIdx int) LayoutModel
+    ```
+  - Store `keys`, `display`, `listWidthRatio` on LayoutModel struct
+  - Pass through to child constructors:
+    - `NewFilterBar(keys, display, windowOptions, defaultPreset, defaultWindowIdx)` (signature from Task 5/7)
+    - `NewSessionList(groups, keys, display)` (signature from Task 8)
+  - Replace all hardcoded key checks in `Update()` with `config.Matches()`:
+    - `"tab"` -> `config.Matches(keyStr, m.keys.CycleFilter)`
+    - `"t"` -> `config.Matches(keyStr, m.keys.CycleTime)`
+    - `"/"` -> `config.Matches(keyStr, m.keys.Search)`
+    - `"left"` -> `config.Matches(keyStr, m.keys.TreeNav)` (for pane context) and `config.Matches(keyStr, m.keys.PaneLeft)` (conceptually the same but used differently)
+    - `"h"` -> `config.Matches(keyStr, m.keys.PaneLeft)`
+    - `"l"`, `"right"` -> `config.Matches(keyStr, m.keys.PaneRight)`
+    - `"enter"` -> `config.Matches(keyStr, m.keys.Launch)`
+  - Update `paneWidths()` to use stored `listWidthRatio`:
+    ```go
+    func (m LayoutModel) paneWidths() (left, right int) {
+        left = int(float64(m.width) * m.listWidthRatio)
+        right = m.width - left - 1
+        if right < 0 {
+            right = 0
+        }
+        return left, right
+    }
+    ```
+  - Update `View()` to use `m.display.ColorHeader` for `activeColor` instead of hardcoded `"#7D56F4"`
+
+  **Must NOT do**:
+  - Do not change pane focus/switching logic beyond key parameterization
+  - Do not change the View rendering structure (border styles, title format)
+  - Do not modify WindowSizeMsg handling logic
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Direct key replacement + one ratio change, follows same pattern as Tasks 7/8
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 3
+  - **Blocks**: Task 12
+  - **Blocked By**: Tasks 2, 3, 5 (needs domain.TimeWindowOption type from Task 5)
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/ui/layout.go:27-33` - NewLayout() constructor to extend
+  - `internal/ui/layout.go:18-25` - LayoutModel struct to add keys/display/ratio/windowOptions/preset/idx fields
+  - `internal/ui/layout.go:94-165` - Full Update() method with all key checks to replace
+  - `internal/ui/layout.go:227-233` - paneWidths() to parameterize with ratio
+  - `internal/ui/layout.go:185-186` - activeColor/inactiveColor to use display config
+
+  **WHY Each Reference Matters**:
+  - layout.go Update() has the most complex key routing (tab routes to filterbar, keys route to different panes based on context) - executor needs to see the full routing logic
+  - paneWidths() shows the exact calculation to parameterize
+  - View() shows where the accent color is used
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: Layout compiles with config wiring
+    Tool: Bash
+    Preconditions: LayoutModel updated
+    Steps:
+      1. Run: go build ./...
+    Expected Result: Compilation succeeds
+    Failure Indicators: Constructor mismatch or missing fields
+    Evidence: .sisyphus/evidence/task-9-compiles.txt
+
+  Scenario: Pane width ratio is configurable (no more hardcoded m.width / 2)
+    Tool: Bash
+    Preconditions: paneWidths() uses m.listWidthRatio
+    Steps:
+      1. Run: grep -c 'm.width / 2' internal/ui/layout.go (expect 0 - hardcoded division removed)
+      2. Run: grep -c 'listWidthRatio' internal/ui/layout.go (expect >= 2 - field declaration + usage in paneWidths)
+      3. Run: go build ./...
+    Expected Result: Zero occurrences of 'm.width / 2'; listWidthRatio field present and used; build succeeds
+    Failure Indicators: 'm.width / 2' still present in paneWidths()
+    Evidence: .sisyphus/evidence/task-9-ratio.txt
+
+  Scenario: Full test suite passes
+    Tool: Bash
+    Preconditions: All changes made
+    Steps:
+      1. Run: go test ./...
+    Expected Result: All tests pass
+    Failure Indicators: Any test failure
+    Evidence: .sisyphus/evidence/task-9-tests.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feat(ui): wire config into LayoutModel`
+  - Files: `internal/ui/layout.go`
+  - Pre-commit: `go build ./...`
+
+- [ ] 10. Wire config into AppModel (keys, refresh, footer)
+
+  **What to do**:
+  - Create new constructor `NewAppWithConfig(cfg config.Config, agg *appcore.Aggregator) AppModel` that replaces `NewAppWithAggregator`:
+    ```go
+    func NewAppWithConfig(cfg config.Config, agg *appcore.Aggregator) AppModel {
+        // Convert config types to domain types HERE (app.go imports both config and domain)
+        windowOptions := buildTimeWindowOptions(cfg) // local helper in app.go: converts config.TimeWindowOption{Hours} -> domain.TimeWindowOption{Duration}, appends "All" sentinel
+        defaultPreset := resolveDefaultPreset(cfg.Defaults.Filter) // local helper: "needs_attention" -> domain.FilterNeedsAttention
+        defaultWindowIdx := resolveDefaultWindowIdx(cfg.Defaults.TimeWindow, windowOptions) // local helper: matches label to index
+        keys := cfg.Keys // KeysConfig fields match KeyMap layout - use directly or copy
+
+        return AppModel{
+            cfg:        cfg,
+            layout:     NewLayout(nil, keys, cfg.Display, cfg.Defaults.ListWidthRatio, windowOptions, defaultPreset, defaultWindowIdx),
+            aggregator: agg,
+            loading:    agg != nil,
+        }
+    }
+    }
+    ```
+  - Keep `NewAppWithAggregator` as a backward-compat wrapper using `config.Default()`
+  - Store `cfg config.Config` on AppModel struct
+  - Replace hardcoded key checks in `Update()`:
+    - `"ctrl+c"` -> `config.Matches(keyStr, m.cfg.Keys.Quit)` (ctrl+c is just part of the Quit binding list)
+    - `"q"` -> same Quit binding (but respecting `!m.layout.IsSearchActive()` guard)
+    - `"r"` -> `config.Matches(keyStr, m.cfg.Keys.Refresh)` (with `!m.layout.IsSearchActive()` guard)
+    - Note: `ctrl+c` should ALWAYS quit (even during search) - keep separate check for ctrl+c specifically, or make Quit binding check ignore search mode for ctrl+c only. Simplest: check quit bindings, and if in search mode, only allow `ctrl+c` from the quit list.
+  - Update `tickCmd()` to use configurable refresh interval:
+    ```go
+    func tickCmd(interval time.Duration) tea.Cmd {
+        return tea.Tick(interval, func(t time.Time) tea.Msg {
+            return refreshMsg{}
+        })
+    }
+    ```
+    Called as `tickCmd(time.Duration(m.cfg.Defaults.RefreshInterval) * time.Second)`
+  - Update footer legend in `View()` to be dynamically generated from KeyMap:
+    ```go
+    func (m AppModel) buildFooterLegend() string {
+        // Format: "j/k up/down  h/l pane  ..."
+        // Becomes dynamic based on actual key bindings
+        return fmt.Sprintf("%s up/down  %s pane  ...", formatKeys(m.cfg.Keys.Down), formatKeys(m.cfg.Keys.PaneLeft))
+    }
+    ```
+    Where `formatKeys(keys []string) string` joins keys with `/` (e.g., `["j", "down"]` -> `"j/down"`)
+  - Update header color to use `m.cfg.Display.ColorHeader`:
+    ```go
+    headerStyle = lipgloss.NewStyle().Bold(true).
+        Foreground(lipgloss.Color("#FAFAFA")).
+        Background(lipgloss.Color(m.cfg.Display.ColorHeader)).
+        Padding(0, 1)
+    ```
+    Note: headerStyle is currently a package-level var. It needs to be computed per-render using config, or set once in the constructor. Prefer constructor-time since config is immutable.
+
+  **Must NOT do**:
+  - Do not add config hot-reload or re-reading
+  - Do not change data loading/refresh logic beyond the interval
+  - Do not modify session launch behavior
+  - Do not remove NewAppWithAggregator (keep as backward-compat wrapper)
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+    - Reason: Most complex UI wiring - touches keys, refresh timing, footer generation, header style, plus constructor chain management
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 3
+  - **Blocks**: Task 12
+  - **Blocked By**: Tasks 2, 3, 5
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/ui/app.go:81-101` - AppModel struct and constructors to extend
+  - `internal/ui/app.go:111-191` - Full Update() with key checks and refresh logic
+  - `internal/ui/app.go:75-79` - tickCmd() with hardcoded 30s interval
+  - `internal/ui/app.go:263-281` - View() with hardcoded header style and footer legend
+  - `internal/ui/app.go:17-21` - Package-level headerStyle var to make config-aware
+  - `internal/ui/app.go:277-279` - Hardcoded footer legend string to generate dynamically
+  - `internal/ui/app.go:172-181` - Key handling for quit (ctrl+c always, q outside search, r outside search)
+
+  **WHY Each Reference Matters**:
+  - app.go Update() has nuanced key handling (ctrl+c vs q behavior differs during search mode) - executor needs to see this to avoid breaking the ctrl+c-always-quits guarantee
+  - tickCmd shows the refresh interval to parameterize
+  - View() footer/header show the exact rendering to change
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: App compiles with config wiring
+    Tool: Bash
+    Preconditions: AppModel updated with config
+    Steps:
+      1. Run: go build ./...
+    Expected Result: Compilation succeeds
+    Failure Indicators: Constructor chain mismatches
+    Evidence: .sisyphus/evidence/task-10-compiles.txt
+
+  Scenario: Backward-compat constructor still works
+    Tool: Bash
+    Preconditions: NewAppWithAggregator kept as wrapper
+    Steps:
+      1. Run: grep -A3 'func NewAppWithAggregator' internal/ui/app.go (expect function exists and calls NewAppWithConfig or config.Default)
+      2. Run: grep -c 'NewAppWithAggregator' internal/ui/app.go (expect >= 1 - function definition present)
+      3. Run: go build ./...
+    Expected Result: NewAppWithAggregator function exists, uses config.Default(), build succeeds
+    Failure Indicators: Function removed; grep returns 0 matches
+    Evidence: .sisyphus/evidence/task-10-compat.txt
+
+  Scenario: No hardcoded key strings in app.go Update()
+    Tool: Bash
+    Preconditions: All key replacements done
+    Steps:
+      1. Run: grep -n 'msg.String() ==' internal/ui/app.go
+      2. Run: grep -c '"q"\|"r"' internal/ui/app.go (expect 0 in key-handling context - these should use config.Matches)
+      3. Run: grep -c 'config.Matches\|Matches(' internal/ui/app.go (expect >= 2 - quit and refresh)
+      4. Run: go build ./...
+    Expected Result: msg.String()== not used for q/r; config.Matches used for quit and refresh; build succeeds
+    Failure Indicators: "q" or "r" in direct string comparison outside of Matches calls
+    Evidence: .sisyphus/evidence/task-10-no-hardcoded.txt
+
+  Scenario: Full test suite passes
+    Tool: Bash
+    Preconditions: All changes made
+    Steps:
+      1. Run: go test ./...
+    Expected Result: All tests pass
+    Failure Indicators: Any test failure
+    Evidence: .sisyphus/evidence/task-10-tests.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feat(ui): wire config into AppModel with configurable refresh and footer`
+  - Files: `internal/ui/app.go`
+  - Pre-commit: `go build ./...`
+
+- [ ] 11. Wire display config into filter bar legend
+
+  **What to do**:
+  - This is a focused follow-up to Task 7 for the View() legend specifically
+  - In `internal/ui/filterbar.go` View(), replace the hardcoded legend icon/color pairs with DisplayConfig lookups:
+    ```go
+    // Before:
+    color("#FF0000", "!") + " err",
+    color("#FF44FF", "@") + " waiting",
+    // ...
+
+    // After:
+    color(m.display.ColorError, m.display.IconError) + " err",
+    color(m.display.ColorWaiting, m.display.IconWaiting) + " waiting",
+    color(m.display.ColorActive, m.display.IconActive) + " active",
+    color(m.display.ColorReply, m.display.IconReply) + " reply",
+    color(m.display.ColorStale, m.display.IconStale) + " stale",
+    color(m.display.ColorTodos, m.display.IconTodos) + " todos",
+    ```
+  - Also update the active filter highlight color in View():
+    ```go
+    // Before:
+    Background(lipgloss.Color("#7D56F4"))
+    // After:
+    Background(lipgloss.Color(m.display.ColorHeader))
+    ```
+  - Note: If Task 7 already did this, this task is a verification pass. If Task 7 focused on keys and left legend colors, this task completes the display wiring.
+
+  **Must NOT do**:
+  - Do not change the legend label text ("err", "waiting", "active", etc.)
+  - Do not add new legend items
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Direct string replacements in one method
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 3
+  - **Blocks**: Task 12
+  - **Blocked By**: Tasks 2, 5, 6
+
+  **References**:
+
+  **Pattern References**:
+  - `internal/ui/filterbar.go:150-160` - Legend section with hardcoded color/icon pairs
+  - `internal/ui/filterbar.go:123-126` - Active preset highlight with `#7D56F4`
+
+  **WHY Each Reference Matters**:
+  - Lines 150-160 are the EXACT lines to change - 6 color/icon pairs
+  - Line 126 is the accent color to parameterize
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: Legend uses display config colors/icons (no hardcoded hex)
+    Tool: Bash
+    Preconditions: filterbar.go View() updated
+    Steps:
+      1. Run: grep -c '#FF0000\|#FF44FF\|#00FF00\|#FFFF00\|#FFA500\|#0088FF' internal/ui/filterbar.go (expect 0 - no hardcoded hex colors)
+      2. Run: grep -c 'm.display\.\|display\.' internal/ui/filterbar.go (expect >= 6 - one per legend entry)
+      3. Run: go build ./...
+    Expected Result: Zero hardcoded color hex strings; display config references present; build succeeds
+    Failure Indicators: Hardcoded hex colors like #FF0000 still in filterbar.go
+    Evidence: .sisyphus/evidence/task-11-legend-config.txt
+
+  Scenario: Full test suite passes
+    Tool: Bash
+    Preconditions: All changes made
+    Steps:
+      1. Run: go test ./...
+    Expected Result: All tests pass
+    Failure Indicators: Any test failure
+    Evidence: .sisyphus/evidence/task-11-tests.txt
+  ```
+
+  **Commit**: YES (can group with Task 7 if done by same agent)
+  - Message: `feat(ui): wire display config into filter bar legend`
+  - Files: `internal/ui/filterbar.go`
+  - Pre-commit: `go build ./...`
+
+- [ ] 12. main.go - Add --config flag, load config, bridge types, wire through
+
+  **What to do**:
+  - In `cmd/opencode-dashboard/main.go`:
+  - Add `--config` flag alongside existing `--db-path`:
+    ```go
+    configPath := flag.String("config", "", "path to config.toml (default: ~/.config/opencode-dashboard/config.toml)")
+    ```
+  - After `flag.Parse()`, load and validate config:
+    ```go
+    cfg, err := config.Load(*configPath)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Config error: %v\n", err)
+        os.Exit(1)
+    }
+    ```
+  - Bridge config thresholds to attention package:
+    ```go
+    thresholds := attention.Thresholds{
+        ActiveNowWindow:     time.Duration(cfg.Thresholds.ActiveNowMinutes) * time.Minute,
+        NeedsResponseWindow: time.Duration(cfg.Thresholds.NeedsResponseHours) * time.Hour,
+        StaleThreshold:      time.Duration(cfg.Thresholds.StaleWorkDays) * 24 * time.Hour,
+    }
+    ```
+  - Create a custom classify closure and inject into aggregator. The existing `NewAggregator()` signature MUST NOT change. Instead, add a NEW constructor:
+    ```go
+    // NewAggregatorWithClassifier creates an Aggregator with a custom attention classifier.
+    func NewAggregatorWithClassifier(
+        classify func(domain.SessionView, time.Time) domain.AttentionSignal,
+        projects domain.ProjectStore,
+        sessions domain.SessionStore,
+        messages domain.MessageStore,
+        todos domain.TodoStore,
+        errors domain.ErrorStore,
+        waiting domain.WaitingStore,
+    ) *Aggregator
+    ```
+    Usage in main.go:
+    ```go
+    classify := func(v domain.SessionView, now time.Time) domain.AttentionSignal {
+        return attention.ClassifyWith(v, now, thresholds)
+    }
+    agg := app.NewAggregatorWithClassifier(classify, projectRepo, sessionRepo, messageRepo, todoRepo, errorRepo, waitingRepo)
+    ```
+  - In `internal/app/aggregator.go`: Add the new constructor. Refactor so both constructors share a common init path (e.g., NewAggregator calls NewAggregatorWithClassifier with `attention.Classify` as the default).
+  - Existing `NewAggregator()` signature and all its call sites (including `aggregator_test.go`) remain COMPLETELY UNCHANGED.
+  - Pass raw config to the UI (time window conversion happens inside `NewAppWithConfig`, NOT in main.go):
+    ```go
+    p := tea.NewProgram(ui.NewAppWithConfig(cfg, agg), tea.WithAltScreen())
+    ```
+  - main.go only converts attention thresholds (config -> attention.Thresholds). All other config-to-domain conversions happen in `ui/app.go` which imports both packages.
+  - Add new imports: `config`, `attention`, `time`
+
+  **Must NOT do**:
+  - Do not add config subcommands (--dump-config, --validate-config)
+  - Do not add environment variable overrides
+  - Do not modify database, store, or repo code
+  - Do not change error handling patterns for existing code
+
+  **Recommended Agent Profile**:
+  - **Category**: `deep`
+    - Reason: Integration point - connects all packages, changes aggregator constructor, must verify everything works end-to-end
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO (depends on all other tasks)
+  - **Parallel Group**: Wave 4 (final implementation)
+  - **Blocks**: F1-F4
+  - **Blocked By**: ALL Tasks 1-11
+
+  **References**:
+
+  **Pattern References**:
+  - `cmd/opencode-dashboard/main.go:16-49` - Full current main.go showing flag parsing, DB opening, repo construction, aggregator creation, and TUI launch. This is the file being modified.
+  - `internal/app/aggregator.go:26-43` - NewAggregator() constructor that needs the classify parameter added
+  - `internal/app/aggregator.go:22` - `classify` field on Aggregator struct (already exists, currently set to `attention.Classify`)
+  - `internal/app/aggregator_test.go` - Test file that calls NewAggregator() - needs updated constructor calls
+  - `internal/attention/classifier.go` - ClassifyWith() function and Thresholds struct (from Task 4)
+  - `internal/config/config.go` - Load() function and Config struct
+  - `internal/ui/app.go` - NewAppWithConfig() constructor (from Task 10)
+
+  **WHY Each Reference Matters**:
+  - main.go is the file being modified - executor sees the exact integration point and current flow
+  - aggregator.go shows the constructor to change and the classify field that receives the closure
+  - aggregator_test.go shows test calls that need updating for the new constructor signature
+  - attention classifier.go provides the ClassifyWith function being wrapped in the closure
+  - config.go provides the Load function being called
+  - ui/app.go provides the new constructor being called
+
+  **QA Scenarios (MANDATORY)**:
+
+  ```
+  Scenario: Binary builds successfully
+    Tool: Bash
+    Preconditions: All Tasks 1-11 completed
+    Steps:
+      1. Run: go build -o /tmp/opencode-dashboard-test ./cmd/opencode-dashboard
+    Expected Result: Binary compiled successfully at /tmp/opencode-dashboard-test
+    Failure Indicators: Compilation error
+    Evidence: .sisyphus/evidence/task-12-build.txt
+
+  Scenario: Help shows --config flag
+    Tool: Bash
+    Preconditions: Binary built
+    Steps:
+      1. Run: /tmp/opencode-dashboard-test --help 2>&1
+    Expected Result: Output contains "--config" flag description mentioning config.toml
+    Failure Indicators: --config not present in help output
+    Evidence: .sisyphus/evidence/task-12-help-flag.txt
+
+  Scenario: Launches successfully without config file
+    Tool: interactive_bash (tmux)
+    Preconditions: Binary built, no config file at default path
+    Steps:
+      1. Create tmux session: new-session -d -s config-test
+      2. Run the dashboard: send-keys -t config-test "/tmp/opencode-dashboard-test --db-path /tmp/nonexistent.db" Enter
+      3. Wait 2 seconds
+      4. Capture output: capture-pane -t config-test -p
+      5. Expected: Dashboard shows "Error opening database" (DB doesn't exist) but NOT a config error
+      6. Kill session: kill-session -t config-test
+    Expected Result: Error message is about DB, not config - proving config silently defaulted
+    Failure Indicators: Config error message appears
+    Evidence: .sisyphus/evidence/task-12-no-config-launch.txt
+
+  Scenario: Invalid config file exits with clear error
+    Tool: Bash
+    Preconditions: Binary built
+    Steps:
+      1. Write invalid TOML to /tmp/bad-config.toml: echo "this is not [valid toml" > /tmp/bad-config.toml
+      2. Run: /tmp/opencode-dashboard-test --config /tmp/bad-config.toml 2>&1; echo "EXIT: $?"
+    Expected Result: stderr contains "Config error", exit code is 1
+    Failure Indicators: No error message, or exit code 0
+    Evidence: .sisyphus/evidence/task-12-bad-config.txt
+
+  Scenario: Explicit --config with nonexistent path exits with error
+    Tool: Bash
+    Preconditions: Binary built
+    Steps:
+      1. Run: /tmp/opencode-dashboard-test --config /nonexistent/path.toml 2>&1; echo "EXIT: $?"
+    Expected Result: stderr contains "Config error", exit code is 1 (not silent fallback)
+    Failure Indicators: Silent fallback to defaults (exit code 0, no error)
+    Evidence: .sisyphus/evidence/task-12-explicit-missing.txt
+
+  Scenario: Full test suite passes
+    Tool: Bash
+    Preconditions: All changes made including aggregator constructor update
+    Steps:
+      1. Run: go test ./...
+    Expected Result: ALL tests pass including updated aggregator tests
+    Failure Indicators: Any test failure
+    Evidence: .sisyphus/evidence/task-12-full-suite.txt
+
+  Scenario: go vet clean
+    Tool: Bash
+    Preconditions: All changes made
+    Steps:
+      1. Run: go vet ./...
+    Expected Result: No warnings or errors
+    Failure Indicators: Any vet warning
+    Evidence: .sisyphus/evidence/task-12-vet.txt
+  ```
+
+  **Commit**: YES
+  - Message: `feat: wire config loading with --config flag in main.go`
+  - Files: `cmd/opencode-dashboard/main.go`, `internal/app/aggregator.go`
+  - Pre-commit: `go test ./...`
+
+---
+
+## Final Verification Wave (MANDATORY - after ALL implementation tasks)
+
+> 4 review agents run in PARALLEL. ALL must APPROVE. Present consolidated results to user and get explicit "okay" before completing.
+>
+> **Do NOT auto-proceed after verification. Wait for user's explicit approval before marking work complete.**
+
+- [ ] F1. **Plan Compliance Audit** - `oracle`
+  Read the plan end-to-end. For each "Must Have": verify implementation exists (read file, run `go test`, check config loading). For each "Must NOT Have": search codebase for forbidden patterns (hot-reload, env var overrides, config subcommands, store modifications). Check evidence files exist in .sisyphus/evidence/. Compare deliverables against plan.
+  Output: `Must Have [N/N] | Must NOT Have [N/N] | Tasks [N/N] | VERDICT: APPROVE/REJECT`
+
+- [ ] F2. **Code Quality Review** - `unspecified-high`
+  Run `go vet ./...` + `go build ./...` + `go test ./...`. Review all changed files for: unnecessary type assertions, empty error handling, unused imports, `fmt.Println` in production code. Check AI slop: excessive comments, over-abstraction, generic variable names (data/result/item/temp). Verify config package imports only stdlib + BurntSushi/toml.
+  Output: `Build [PASS/FAIL] | Vet [PASS/FAIL] | Tests [N pass/N fail] | Files [N clean/N issues] | VERDICT`
+
+- [ ] F3. **Real Manual QA** - `unspecified-high`
+  Start from clean state. Execute EVERY QA scenario from EVERY task - follow exact steps, capture evidence. Test cross-task integration: launch TUI without config (defaults), launch with partial config, launch with full config, launch with invalid config. Test keybinding changes actually work in the TUI. Save to `.sisyphus/evidence/final-qa/`.
+  Output: `Scenarios [N/N pass] | Integration [N/N] | Edge Cases [N tested] | VERDICT`
+
+- [ ] F4. **Scope Fidelity Check** - `deep`
+  For each task: read "What to do", read actual diff (git log/diff). Verify 1:1 - everything in spec was built (no missing), nothing beyond spec was built (no creep). Check "Must NOT do" compliance. Verify store layer has ZERO changes. Verify FilterPreset is not configurable. Flag unaccounted changes.
+  Output: `Tasks [N/N compliant] | Contamination [CLEAN/N issues] | Unaccounted [CLEAN/N files] | VERDICT`
+
+---
+
+## Commit Strategy
+
+| Order | Scope | Message | Files | Pre-commit |
+|-------|-------|---------|-------|------------|
+| 1 | deps | `chore: add BurntSushi/toml dependency` | go.mod, go.sum | `go build ./...` |
+| 2 | config | `feat(config): add config package with TOML loading and validation` | internal/config/*.go | `go test ./internal/config/` |
+| 3 | config | `feat(config): add KeyMap struct with key matching` | internal/config/keys*.go | `go test ./internal/config/` |
+| 4 | attention | `feat(attention): add configurable thresholds via ClassifyWith` | internal/attention/classifier*.go | `go test ./internal/attention/` |
+| 5 | domain+filter+ui | `refactor: replace TimeWindow enum with config-driven TimeWindowOption` | internal/domain/types.go, internal/filter/filter*.go, internal/ui/filterbar.go | `go test ./...` |
+| 6 | ui | `refactor(ui): extract display config helpers in styles.go` | internal/ui/styles.go | `go build ./...` |
+| 7-11 | ui | `feat(ui): wire config into {component}` | internal/ui/{component}.go | `go build ./...` |
+| 12 | main | `feat: wire config loading with --config flag in main.go` | cmd/opencode-dashboard/main.go, internal/app/aggregator.go | `go test ./...` |
+
+---
+
+## Success Criteria
+
+### Verification Commands
+```bash
+go vet ./...                    # Expected: clean, no warnings
+go build ./cmd/opencode-dashboard  # Expected: compiles successfully
+go test ./...                   # Expected: all tests pass (existing + new)
+go test -v ./internal/config/   # Expected: config loading, merging, validation, KeyMap tests pass
+go test -v ./internal/attention/ # Expected: all 14 existing + new ClassifyWith tests pass
+go test -v ./internal/filter/   # Expected: all existing + updated window tests pass
+```
+
+### Final Checklist
+- [ ] All "Must Have" present and verified via tests
+- [ ] All "Must NOT Have" absent (no hot-reload, no env vars, no store changes, no preset config)
+- [ ] All existing tests pass unmodified (backward compatibility)
+- [ ] Config Default() values exactly match current hardcoded behavior
+- [ ] `go test ./...` passes
+- [ ] `go vet ./...` clean
+- [ ] `go build ./cmd/opencode-dashboard` succeeds

--- a/.sisyphus/plans/user-config.md
+++ b/.sisyphus/plans/user-config.md
@@ -618,7 +618,7 @@ Max Concurrent: 5 (Wave 3)
   - Files: `internal/attention/classifier.go`, `internal/attention/classifier_test.go`
   - Pre-commit: `go test ./internal/attention/`
 
-- [ ] 5. Replace TimeWindow enum with config-driven TimeWindowOption (ATOMIC)
+- [x] 5. Replace TimeWindow enum with config-driven TimeWindowOption (ATOMIC)
 
   **What to do**:
   This is an ATOMIC change across 4 files. All changes must happen in a single commit because the type is shared.
@@ -760,7 +760,7 @@ Max Concurrent: 5 (Wave 3)
   - Files: `internal/domain/types.go`, `internal/filter/filter.go`, `internal/filter/filter_test.go`, `internal/ui/filterbar.go`, `internal/ui/app.go`, `internal/config/config.go`
   - Pre-commit: `go test ./...`
 
-- [ ] 6. Display config helpers in styles.go
+- [x] 6. Display config helpers in styles.go
 
   **What to do**:
   - In `internal/ui/styles.go`, modify `attentionIcon()` and `attentionIconPlain()` to accept a `config.DisplayConfig` parameter:

--- a/.sisyphus/plans/user-config.md
+++ b/.sisyphus/plans/user-config.md
@@ -849,7 +849,7 @@ Max Concurrent: 5 (Wave 3)
   - Files: `internal/ui/styles.go`, `internal/ui/sessionlist.go`
   - Pre-commit: `go build ./...`
 
-- [ ] 7. Wire config into FilterBarModel
+- [x] 7. Wire config into FilterBarModel
 
   **What to do**:
   - Update `NewFilterBar()` signature to accept config parameters:
@@ -941,7 +941,7 @@ Max Concurrent: 5 (Wave 3)
   - Files: `internal/ui/filterbar.go`
   - Pre-commit: `go build ./...`
 
-- [ ] 8. Wire config into SessionListModel
+- [x] 8. Wire config into SessionListModel
 
   **What to do**:
   - Update `NewSessionList()` to accept KeyMap and DisplayConfig:
@@ -1025,7 +1025,7 @@ Max Concurrent: 5 (Wave 3)
   - Files: `internal/ui/sessionlist.go`
   - Pre-commit: `go build ./...`
 
-- [ ] 9. Wire config into LayoutModel
+- [x] 9. Wire config into LayoutModel
 
   **What to do**:
   - Update `NewLayout()` to accept all config needed by itself and its children:
@@ -1125,7 +1125,7 @@ Max Concurrent: 5 (Wave 3)
   - Files: `internal/ui/layout.go`
   - Pre-commit: `go build ./...`
 
-- [ ] 10. Wire config into AppModel (keys, refresh, footer)
+- [x] 10. Wire config into AppModel (keys, refresh, footer)
 
   **What to do**:
   - Create new constructor `NewAppWithConfig(cfg config.Config, agg *appcore.Aggregator) AppModel` that replaces `NewAppWithAggregator`:
@@ -1263,7 +1263,7 @@ Max Concurrent: 5 (Wave 3)
   - Files: `internal/ui/app.go`
   - Pre-commit: `go build ./...`
 
-- [ ] 11. Wire display config into filter bar legend
+- [x] 11. Wire display config into filter bar legend
 
   **What to do**:
   - This is a focused follow-up to Task 7 for the View() legend specifically
@@ -1345,7 +1345,7 @@ Max Concurrent: 5 (Wave 3)
   - Files: `internal/ui/filterbar.go`
   - Pre-commit: `go build ./...`
 
-- [ ] 12. main.go - Add --config flag, load config, bridge types, wire through
+- [x] 12. main.go - Add --config flag, load config, bridge types, wire through
 
   **What to do**:
   - In `cmd/opencode-dashboard/main.go`:

--- a/cmd/opencode-dashboard/main.go
+++ b/cmd/opencode-dashboard/main.go
@@ -6,9 +6,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/joeyparis/opencode-dashboard/internal/app"
+	"github.com/joeyparis/opencode-dashboard/internal/attention"
+	"github.com/joeyparis/opencode-dashboard/internal/config"
+	"github.com/joeyparis/opencode-dashboard/internal/domain"
 	"github.com/joeyparis/opencode-dashboard/internal/store"
 	"github.com/joeyparis/opencode-dashboard/internal/ui"
 )
@@ -18,7 +22,23 @@ func main() {
 	defaultDB := filepath.Join(home, ".local", "share", "opencode", "opencode.db")
 
 	dbPath := flag.String("db-path", defaultDB, "path to OpenCode SQLite database")
+	configPath := flag.String("config", "", "path to config.toml (default: ~/.config/opencode-dashboard/config.toml)")
 	flag.Parse()
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Config error: %v\n", err)
+		os.Exit(1)
+	}
+
+	thresholds := attention.Thresholds{
+		ActiveNowWindow:     time.Duration(cfg.Thresholds.ActiveNowMinutes) * time.Minute,
+		NeedsResponseWindow: time.Duration(cfg.Thresholds.NeedsResponseHours) * time.Hour,
+		StaleThreshold:      time.Duration(cfg.Thresholds.StaleWorkDays) * 24 * time.Hour,
+	}
+	classify := func(v domain.SessionView, now time.Time) domain.AttentionSignal {
+		return attention.ClassifyWith(v, now, thresholds)
+	}
 
 	db, err := store.NewDB(*dbPath)
 	if err != nil {
@@ -40,8 +60,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	agg := app.NewAggregator(projectRepo, sessionRepo, messageRepo, todoRepo, errorRepo, waitingRepo)
-	p := tea.NewProgram(ui.NewAppWithAggregator(agg), tea.WithAltScreen())
+	agg := app.NewAggregatorWithClassifier(classify, projectRepo, sessionRepo, messageRepo, todoRepo, errorRepo, waitingRepo)
+	p := tea.NewProgram(ui.NewAppWithConfig(cfg, agg), tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/internal/app/aggregator.go
+++ b/internal/app/aggregator.go
@@ -84,6 +84,8 @@ func (a *Aggregator) LoadAll(ctx context.Context) ([]domain.ProjectGroup, error)
 	viewsByProject := make(map[string][]domain.SessionView)
 
 	for _, s := range sessions {
+		// Best-effort enrichment: data fetch failures degrade gracefully to zero values
+		// rather than aborting the session load entirely.
 		todos, _ := a.todos.GetTodosBySession(ctx, s.ID)
 		lastMsg, _ := a.messages.GetLastMessageMeta(ctx, s.ID)
 		msgCount, _ := a.messages.GetMessageCount(ctx, s.ID)
@@ -122,7 +124,7 @@ func (a *Aggregator) LoadAll(ctx context.Context) ([]domain.ProjectGroup, error)
 	}
 
 	// Build ProjectGroups
-	groups := make([]domain.ProjectGroup, 0, len(projects))
+	grouped := make([]domain.ProjectGroup, 0, len(projects))
 	for _, p := range projects {
 		views := viewsByProject[p.ID]
 
@@ -137,7 +139,7 @@ func (a *Aggregator) LoadAll(ctx context.Context) ([]domain.ProjectGroup, error)
 			}
 		}
 
-		groups = append(groups, domain.ProjectGroup{
+		grouped = append(grouped, domain.ProjectGroup{
 			Project:        p,
 			Sessions:       views,
 			AttentionCount: attentionCount,
@@ -145,16 +147,16 @@ func (a *Aggregator) LoadAll(ctx context.Context) ([]domain.ProjectGroup, error)
 	}
 
 	// Sort groups: alphabetical by DisplayName, Global always last
-	sort.SliceStable(groups, func(i, j int) bool {
-		iGlobal := groups[i].Project.ID == "global" || groups[i].Project.Worktree == "/"
-		jGlobal := groups[j].Project.ID == "global" || groups[j].Project.Worktree == "/"
+	sort.SliceStable(grouped, func(i, j int) bool {
+		iGlobal := grouped[i].Project.ID == "global" || grouped[i].Project.Worktree == "/"
+		jGlobal := grouped[j].Project.ID == "global" || grouped[j].Project.Worktree == "/"
 		if iGlobal != jGlobal {
 			return !iGlobal // non-global comes before global
 		}
-		return strings.ToLower(groups[i].Project.DisplayName()) < strings.ToLower(groups[j].Project.DisplayName())
+		return strings.ToLower(grouped[i].Project.DisplayName()) < strings.ToLower(grouped[j].Project.DisplayName())
 	})
 
-	return groups, nil
+	return grouped, nil
 }
 
 // Refresh refreshes the error and waiting caches then returns the same result as LoadAll.

--- a/internal/app/aggregator.go
+++ b/internal/app/aggregator.go
@@ -31,6 +31,19 @@ func NewAggregator(
 	errors domain.ErrorStore,
 	waiting domain.WaitingStore,
 ) *Aggregator {
+	return NewAggregatorWithClassifier(attention.Classify, projects, sessions, messages, todos, errors, waiting)
+}
+
+// NewAggregatorWithClassifier creates an Aggregator with a custom attention classifier.
+func NewAggregatorWithClassifier(
+	classify func(domain.SessionView, time.Time) domain.AttentionSignal,
+	projects domain.ProjectStore,
+	sessions domain.SessionStore,
+	messages domain.MessageStore,
+	todos domain.TodoStore,
+	errors domain.ErrorStore,
+	waiting domain.WaitingStore,
+) *Aggregator {
 	return &Aggregator{
 		projects: projects,
 		sessions: sessions,
@@ -38,7 +51,7 @@ func NewAggregator(
 		todos:    todos,
 		errors:   errors,
 		waiting:  waiting,
-		classify: attention.Classify,
+		classify: classify,
 	}
 }
 

--- a/internal/attention/classifier.go
+++ b/internal/attention/classifier.go
@@ -12,7 +12,24 @@ const (
 	StaleThreshold      = 7 * 24 * time.Hour
 )
 
-func Classify(view domain.SessionView, now time.Time) domain.AttentionSignal {
+// Thresholds configures attention classifier time windows.
+type Thresholds struct {
+	ActiveNowWindow     time.Duration
+	NeedsResponseWindow time.Duration
+	StaleThreshold      time.Duration
+}
+
+// DefaultThresholds returns the built-in default attention thresholds.
+func DefaultThresholds() Thresholds {
+	return Thresholds{
+		ActiveNowWindow:     ActiveNowWindow,
+		NeedsResponseWindow: NeedsResponseWindow,
+		StaleThreshold:      StaleThreshold,
+	}
+}
+
+// ClassifyWith classifies a session using configurable thresholds.
+func ClassifyWith(view domain.SessionView, now time.Time, t Thresholds) domain.AttentionSignal {
 	if view.IsArchived() {
 		return domain.None
 	}
@@ -27,16 +44,16 @@ func Classify(view domain.SessionView, now time.Time) domain.AttentionSignal {
 		return domain.WaitingForInput
 	}
 
-	if age < ActiveNowWindow {
+	if age < t.ActiveNowWindow {
 		return domain.ActiveNow
 	}
 
-	if view.LastMessage.Role == "assistant" && age < NeedsResponseWindow {
+	if view.LastMessage.Role == "assistant" && age < t.NeedsResponseWindow {
 		return domain.NeedsResponse
 	}
 
 	if view.PendingTodoCount > 0 {
-		if age >= StaleThreshold {
+		if age >= t.StaleThreshold {
 			return domain.StaleWork
 		}
 
@@ -44,4 +61,8 @@ func Classify(view domain.SessionView, now time.Time) domain.AttentionSignal {
 	}
 
 	return domain.None
+}
+
+func Classify(view domain.SessionView, now time.Time) domain.AttentionSignal {
+	return ClassifyWith(view, now, DefaultThresholds())
 }

--- a/internal/attention/classifier_test.go
+++ b/internal/attention/classifier_test.go
@@ -146,6 +146,82 @@ func TestClassify_UserMessageDoesNotNeedResponse(t *testing.T) {
 	assert.Equal(t, domain.None, Classify(view, now))
 }
 
+func TestClassifyWith_CustomActiveWindow(t *testing.T) {
+	now := fixedNow()
+	view := domain.SessionView{}
+	view.TimeUpdated = now.Add(-7 * time.Minute)
+
+	// With custom 10-minute active window, 7-minute-old session is ActiveNow
+	customThresholds := Thresholds{
+		ActiveNowWindow:     10 * time.Minute,
+		NeedsResponseWindow: NeedsResponseWindow,
+		StaleThreshold:      StaleThreshold,
+	}
+	assert.Equal(t, domain.ActiveNow, ClassifyWith(view, now, customThresholds))
+
+	// With default 5-minute window, same session would be None
+	assert.Equal(t, domain.None, Classify(view, now))
+}
+
+func TestClassifyWith_CustomNeedsResponseWindow(t *testing.T) {
+	now := fixedNow()
+	view := domain.SessionView{
+		LastMessage: domain.MessageMeta{Role: "assistant"},
+	}
+	view.TimeUpdated = now.Add(-30 * time.Hour)
+
+	// With custom 48-hour response window, 30-hour-old session is NeedsResponse
+	customThresholds := Thresholds{
+		ActiveNowWindow:     ActiveNowWindow,
+		NeedsResponseWindow: 48 * time.Hour,
+		StaleThreshold:      StaleThreshold,
+	}
+	assert.Equal(t, domain.NeedsResponse, ClassifyWith(view, now, customThresholds))
+
+	// With default 24-hour window, same session would be None
+	assert.Equal(t, domain.None, Classify(view, now))
+}
+
+func TestClassifyWith_CustomStaleThreshold(t *testing.T) {
+	now := fixedNow()
+	view := domain.SessionView{PendingTodoCount: 2}
+	view.TimeUpdated = now.Add(-4 * 24 * time.Hour)
+
+	// With custom 3-day stale threshold, 4-day-old session is StaleWork
+	customThresholds := Thresholds{
+		ActiveNowWindow:     ActiveNowWindow,
+		NeedsResponseWindow: NeedsResponseWindow,
+		StaleThreshold:      3 * 24 * time.Hour,
+	}
+	assert.Equal(t, domain.StaleWork, ClassifyWith(view, now, customThresholds))
+
+	// With default 7-day threshold, same session would be PendingTodos
+	assert.Equal(t, domain.PendingTodos, Classify(view, now))
+}
+
+func TestClassifyWith_DefaultThresholdsMatchClassify(t *testing.T) {
+	now := fixedNow()
+
+	testCases := []domain.SessionView{
+		{ErrorCount: 3},
+		{},
+		{LastMessage: domain.MessageMeta{Role: "assistant"}},
+		{PendingTodoCount: 2},
+		{
+			ErrorCount:       1,
+			LastMessage:      domain.MessageMeta{Role: "assistant"},
+			PendingTodoCount: 2,
+		},
+	}
+
+	for _, view := range testCases {
+		view.TimeUpdated = now.Add(-1 * time.Hour)
+		expected := Classify(view, now)
+		actual := ClassifyWith(view, now, DefaultThresholds())
+		assert.Equal(t, expected, actual, "ClassifyWith(DefaultThresholds()) should match Classify()")
+	}
+}
+
 func fixedNow() time.Time {
 	return time.Date(2026, time.April, 8, 12, 0, 0, 0, time.UTC)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,203 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+type Config struct {
+	Defaults    DefaultsConfig    `toml:"defaults"`
+	Thresholds  ThresholdsConfig  `toml:"thresholds"`
+	TimeWindows TimeWindowsConfig `toml:"time_windows"`
+	Keys        KeysConfig        `toml:"keys"`
+	Display     DisplayConfig     `toml:"display"`
+}
+
+type DefaultsConfig struct {
+	Filter          string  `toml:"filter"`
+	TimeWindow      string  `toml:"time_window"`
+	RefreshInterval int     `toml:"refresh_interval"`
+	ListWidthRatio  float64 `toml:"list_width_ratio"`
+}
+
+type ThresholdsConfig struct {
+	ActiveNowMinutes   int `toml:"active_now_minutes"`
+	NeedsResponseHours int `toml:"needs_response_hours"`
+	StaleWorkDays      int `toml:"stale_work_days"`
+}
+
+type TimeWindowsConfig struct {
+	Options []TimeWindowOption `toml:"options"`
+}
+
+type TimeWindowOption struct {
+	Label string `toml:"label"`
+	Hours int    `toml:"hours"`
+}
+
+type KeysConfig struct {
+	Up          []string `toml:"up"`
+	Down        []string `toml:"down"`
+	PaneLeft    []string `toml:"pane_left"`
+	PaneRight   []string `toml:"pane_right"`
+	TreeNav     []string `toml:"tree_nav"`
+	Collapse    []string `toml:"collapse"`
+	CycleFilter []string `toml:"cycle_filter"`
+	CycleTime   []string `toml:"cycle_time"`
+	Search      []string `toml:"search"`
+	Refresh     []string `toml:"refresh"`
+	Launch      []string `toml:"launch"`
+	Quit        []string `toml:"quit"`
+}
+
+type DisplayConfig struct {
+	IconError     string `toml:"icon_error"`
+	IconWaiting   string `toml:"icon_waiting"`
+	IconActive    string `toml:"icon_active"`
+	IconReply     string `toml:"icon_reply"`
+	IconStale     string `toml:"icon_stale"`
+	IconTodos     string `toml:"icon_todos"`
+	ColorError    string `toml:"color_error"`
+	ColorWaiting  string `toml:"color_waiting"`
+	ColorActive   string `toml:"color_active"`
+	ColorReply    string `toml:"color_reply"`
+	ColorStale    string `toml:"color_stale"`
+	ColorTodos    string `toml:"color_todos"`
+	ColorSelected string `toml:"color_selected"`
+	ColorHeader   string `toml:"color_header"`
+}
+
+func Default() Config {
+	return Config{
+		Defaults: DefaultsConfig{
+			Filter:          "needs_attention",
+			TimeWindow:      "3d",
+			RefreshInterval: 30,
+			ListWidthRatio:  0.5,
+		},
+		Thresholds: ThresholdsConfig{
+			ActiveNowMinutes:   5,
+			NeedsResponseHours: 24,
+			StaleWorkDays:      7,
+		},
+		TimeWindows: TimeWindowsConfig{
+			Options: []TimeWindowOption{
+				{Label: "1d", Hours: 24},
+				{Label: "3d", Hours: 72},
+				{Label: "7d", Hours: 168},
+			},
+		},
+		Keys: KeysConfig{
+			Up:          []string{"k", "up"},
+			Down:        []string{"j", "down"},
+			PaneLeft:    []string{"h"},
+			PaneRight:   []string{"l", "right"},
+			TreeNav:     []string{"left"},
+			Collapse:    []string{" "},
+			CycleFilter: []string{"tab"},
+			CycleTime:   []string{"t"},
+			Search:      []string{"/"},
+			Refresh:     []string{"r"},
+			Launch:      []string{"enter"},
+			Quit:        []string{"q", "ctrl+c"},
+		},
+		Display: DisplayConfig{
+			IconError:     "!",
+			IconWaiting:   "@",
+			IconActive:    "*",
+			IconReply:     "?",
+			IconStale:     "~",
+			IconTodos:     ".",
+			ColorError:    "#FF0000",
+			ColorWaiting:  "#FF44FF",
+			ColorActive:   "#00FF00",
+			ColorReply:    "#FFFF00",
+			ColorStale:    "#FFA500",
+			ColorTodos:    "#0088FF",
+			ColorSelected: "",
+			ColorHeader:   "#7D56F4",
+		},
+	}
+}
+
+func Load(explicitPath string) (Config, error) {
+	path := explicitPath
+	if path == "" {
+		path = ResolvePath()
+		if path == "" {
+			return Default(), nil
+		}
+	} else {
+		if _, err := os.Stat(path); err != nil {
+			return Config{}, err
+		}
+	}
+
+	cfg := Default()
+	meta, err := toml.DecodeFile(path, &cfg)
+	if err != nil {
+		return Config{}, err
+	}
+
+	for _, key := range meta.Undecoded() {
+		_, _ = fmt.Fprintf(os.Stderr, "warning: unknown config key: %s\n", key)
+	}
+
+	if err := Validate(cfg); err != nil {
+		return Config{}, err
+	}
+
+	return cfg, nil
+}
+
+func ResolvePath() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		path := filepath.Join(xdg, "opencode-dashboard", "config.toml")
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+
+	path := filepath.Join(home, ".config", "opencode-dashboard", "config.toml")
+	if _, err := os.Stat(path); err == nil {
+		return path
+	}
+
+	return ""
+}
+
+func Validate(cfg Config) error {
+	if cfg.Defaults.RefreshInterval < 10 {
+		return fmt.Errorf("defaults.refresh_interval must be >= 10")
+	}
+
+	if cfg.Defaults.ListWidthRatio < 0.2 || cfg.Defaults.ListWidthRatio > 0.8 {
+		return fmt.Errorf("defaults.list_width_ratio must be between 0.2 and 0.8")
+	}
+
+	if cfg.Thresholds.ActiveNowMinutes <= 0 {
+		return fmt.Errorf("thresholds.active_now_minutes must be > 0")
+	}
+
+	if cfg.Thresholds.NeedsResponseHours <= 0 {
+		return fmt.Errorf("thresholds.needs_response_hours must be > 0")
+	}
+
+	if cfg.Thresholds.StaleWorkDays <= 0 {
+		return fmt.Errorf("thresholds.stale_work_days must be > 0")
+	}
+
+	if len(cfg.Keys.Quit) == 0 {
+		return fmt.Errorf("keys.quit must not be empty")
+	}
+
+	return nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,365 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefault_AllFieldsPopulated(t *testing.T) {
+	cfg := Default()
+
+	assert.NotEmpty(t, cfg.Defaults.Filter)
+	assert.NotEmpty(t, cfg.Defaults.TimeWindow)
+	assert.NotZero(t, cfg.Defaults.RefreshInterval)
+	assert.NotZero(t, cfg.Defaults.ListWidthRatio)
+
+	assert.NotZero(t, cfg.Thresholds.ActiveNowMinutes)
+	assert.NotZero(t, cfg.Thresholds.NeedsResponseHours)
+	assert.NotZero(t, cfg.Thresholds.StaleWorkDays)
+
+	assert.NotEmpty(t, cfg.TimeWindows.Options)
+	for _, option := range cfg.TimeWindows.Options {
+		assert.NotEmpty(t, option.Label)
+		assert.NotZero(t, option.Hours)
+	}
+
+	assert.NotEmpty(t, cfg.Keys.Up)
+	assert.NotEmpty(t, cfg.Keys.Down)
+	assert.NotEmpty(t, cfg.Keys.PaneLeft)
+	assert.NotEmpty(t, cfg.Keys.PaneRight)
+	assert.NotEmpty(t, cfg.Keys.TreeNav)
+	assert.NotEmpty(t, cfg.Keys.Collapse)
+	assert.NotEmpty(t, cfg.Keys.CycleFilter)
+	assert.NotEmpty(t, cfg.Keys.CycleTime)
+	assert.NotEmpty(t, cfg.Keys.Search)
+	assert.NotEmpty(t, cfg.Keys.Refresh)
+	assert.NotEmpty(t, cfg.Keys.Launch)
+	assert.NotEmpty(t, cfg.Keys.Quit)
+
+	assert.NotEmpty(t, cfg.Display.IconError)
+	assert.NotEmpty(t, cfg.Display.IconWaiting)
+	assert.NotEmpty(t, cfg.Display.IconActive)
+	assert.NotEmpty(t, cfg.Display.IconReply)
+	assert.NotEmpty(t, cfg.Display.IconStale)
+	assert.NotEmpty(t, cfg.Display.IconTodos)
+	assert.NotEmpty(t, cfg.Display.ColorError)
+	assert.NotEmpty(t, cfg.Display.ColorWaiting)
+	assert.NotEmpty(t, cfg.Display.ColorActive)
+	assert.NotEmpty(t, cfg.Display.ColorReply)
+	assert.NotEmpty(t, cfg.Display.ColorStale)
+	assert.NotEmpty(t, cfg.Display.ColorTodos)
+	assert.NotEmpty(t, cfg.Display.ColorHeader)
+}
+
+func TestDefault_GoldenValues(t *testing.T) {
+	cfg := Default()
+
+	assert.Equal(t, 30, cfg.Defaults.RefreshInterval)
+	assert.Equal(t, 5, cfg.Thresholds.ActiveNowMinutes)
+	assert.Equal(t, 24, cfg.Thresholds.NeedsResponseHours)
+	assert.Equal(t, 7, cfg.Thresholds.StaleWorkDays)
+	assert.Equal(t, 0.5, cfg.Defaults.ListWidthRatio)
+	assert.Equal(t, "!", cfg.Display.IconError)
+	assert.Equal(t, "#FF0000", cfg.Display.ColorError)
+	assert.Equal(t, "#7D56F4", cfg.Display.ColorHeader)
+}
+
+func TestLoad_MissingFile_ReturnsDefaults(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	cfg, err := Load("")
+
+	assert.NoError(t, err)
+	assert.Equal(t, Default(), cfg)
+}
+
+func TestLoad_ExplicitPathMissing_ReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.toml")
+
+	_, err := Load(path)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, path)
+}
+
+func TestLoad_EmptyFile_ReturnsDefaults(t *testing.T) {
+	path := writeTempConfig(t, "")
+
+	cfg, err := Load(path)
+
+	assert.NoError(t, err)
+	assert.Equal(t, Default(), cfg)
+}
+
+func TestLoad_PartialConfig_MergesDefaults(t *testing.T) {
+	path := writeTempConfig(t, `
+[thresholds]
+active_now_minutes = 15
+needs_response_hours = 48
+stale_work_days = 14
+`)
+
+	cfg, err := Load(path)
+
+	assert.NoError(t, err)
+	assert.Equal(t, Default().Defaults, cfg.Defaults)
+	assert.Equal(t, ThresholdsConfig{
+		ActiveNowMinutes:   15,
+		NeedsResponseHours: 48,
+		StaleWorkDays:      14,
+	}, cfg.Thresholds)
+	assert.Equal(t, Default().TimeWindows, cfg.TimeWindows)
+	assert.Equal(t, Default().Keys, cfg.Keys)
+	assert.Equal(t, Default().Display, cfg.Display)
+}
+
+func TestLoad_FullConfig(t *testing.T) {
+	path := writeTempConfig(t, `
+[defaults]
+filter = "all"
+time_window = "7d"
+refresh_interval = 60
+list_width_ratio = 0.33
+
+[thresholds]
+active_now_minutes = 10
+needs_response_hours = 12
+stale_work_days = 21
+
+[[time_windows.options]]
+label = "12h"
+hours = 12
+
+[[time_windows.options]]
+label = "30d"
+hours = 720
+
+[keys]
+up = ["w"]
+down = ["s"]
+pane_left = ["a"]
+pane_right = ["d"]
+tree_nav = ["backspace"]
+collapse = ["space"]
+cycle_filter = ["f"]
+cycle_time = ["y"]
+search = ["ctrl+f"]
+refresh = ["F5"]
+launch = ["o"]
+quit = ["esc"]
+
+[display]
+icon_error = "E"
+icon_waiting = "W"
+icon_active = "A"
+icon_reply = "R"
+icon_stale = "S"
+icon_todos = "T"
+color_error = "#111111"
+color_waiting = "#222222"
+color_active = "#333333"
+color_reply = "#444444"
+color_stale = "#555555"
+color_todos = "#666666"
+color_selected = "#777777"
+color_header = "#888888"
+`)
+
+	cfg, err := Load(path)
+
+	assert.NoError(t, err)
+	assert.Equal(t, Config{
+		Defaults: DefaultsConfig{
+			Filter:          "all",
+			TimeWindow:      "7d",
+			RefreshInterval: 60,
+			ListWidthRatio:  0.33,
+		},
+		Thresholds: ThresholdsConfig{
+			ActiveNowMinutes:   10,
+			NeedsResponseHours: 12,
+			StaleWorkDays:      21,
+		},
+		TimeWindows: TimeWindowsConfig{Options: []TimeWindowOption{{Label: "12h", Hours: 12}, {Label: "30d", Hours: 720}}},
+		Keys: KeysConfig{
+			Up:          []string{"w"},
+			Down:        []string{"s"},
+			PaneLeft:    []string{"a"},
+			PaneRight:   []string{"d"},
+			TreeNav:     []string{"backspace"},
+			Collapse:    []string{"space"},
+			CycleFilter: []string{"f"},
+			CycleTime:   []string{"y"},
+			Search:      []string{"ctrl+f"},
+			Refresh:     []string{"F5"},
+			Launch:      []string{"o"},
+			Quit:        []string{"esc"},
+		},
+		Display: DisplayConfig{
+			IconError:     "E",
+			IconWaiting:   "W",
+			IconActive:    "A",
+			IconReply:     "R",
+			IconStale:     "S",
+			IconTodos:     "T",
+			ColorError:    "#111111",
+			ColorWaiting:  "#222222",
+			ColorActive:   "#333333",
+			ColorReply:    "#444444",
+			ColorStale:    "#555555",
+			ColorTodos:    "#666666",
+			ColorSelected: "#777777",
+			ColorHeader:   "#888888",
+		},
+	}, cfg)
+}
+
+func TestLoad_ParseError_ReturnsError(t *testing.T) {
+	path := writeTempConfig(t, `
+[defaults
+filter = "broken"
+`)
+
+	_, err := Load(path)
+
+	assert.Error(t, err)
+}
+
+func TestLoad_SliceReplacement(t *testing.T) {
+	path := writeTempConfig(t, `
+[[time_windows.options]]
+label = "30m"
+hours = 1
+`)
+
+	cfg, err := Load(path)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []TimeWindowOption{{Label: "30m", Hours: 1}}, cfg.TimeWindows.Options)
+}
+
+func TestValidate_RefreshTooLow(t *testing.T) {
+	cfg := Default()
+	cfg.Defaults.RefreshInterval = 5
+
+	err := Validate(cfg)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "defaults.refresh_interval")
+}
+
+func TestValidate_RatioOutOfRange(t *testing.T) {
+	t.Run("too low", func(t *testing.T) {
+		cfg := Default()
+		cfg.Defaults.ListWidthRatio = 0.0
+
+		err := Validate(cfg)
+
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "defaults.list_width_ratio")
+	})
+
+	t.Run("too high", func(t *testing.T) {
+		cfg := Default()
+		cfg.Defaults.ListWidthRatio = 1.0
+
+		err := Validate(cfg)
+
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "defaults.list_width_ratio")
+	})
+
+	t.Run("lower bound ok", func(t *testing.T) {
+		cfg := Default()
+		cfg.Defaults.ListWidthRatio = 0.2
+
+		assert.NoError(t, Validate(cfg))
+	})
+
+	t.Run("upper bound ok", func(t *testing.T) {
+		cfg := Default()
+		cfg.Defaults.ListWidthRatio = 0.8
+
+		assert.NoError(t, Validate(cfg))
+	})
+}
+
+func TestValidate_NegativeThresholds(t *testing.T) {
+	t.Run("active now minutes", func(t *testing.T) {
+		cfg := Default()
+		cfg.Thresholds.ActiveNowMinutes = 0
+
+		err := Validate(cfg)
+
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "thresholds.active_now_minutes")
+	})
+
+	t.Run("needs response hours", func(t *testing.T) {
+		cfg := Default()
+		cfg.Thresholds.NeedsResponseHours = 0
+
+		err := Validate(cfg)
+
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "thresholds.needs_response_hours")
+	})
+
+	t.Run("stale work days", func(t *testing.T) {
+		cfg := Default()
+		cfg.Thresholds.StaleWorkDays = 0
+
+		err := Validate(cfg)
+
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "thresholds.stale_work_days")
+	})
+}
+
+func TestValidate_EmptyQuitBinding(t *testing.T) {
+	cfg := Default()
+	cfg.Keys.Quit = nil
+
+	err := Validate(cfg)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "keys.quit")
+}
+
+func TestResolvePath_XDGOverride(t *testing.T) {
+	xdgHome := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgHome)
+	t.Setenv("HOME", home)
+
+	expected := filepath.Join(xdgHome, "opencode-dashboard", "config.toml")
+	assert.NoError(t, os.MkdirAll(filepath.Dir(expected), 0o755))
+	assert.NoError(t, os.WriteFile(expected, []byte(""), 0o644))
+
+	assert.Equal(t, expected, ResolvePath())
+}
+
+func TestResolvePath_HomeFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", home)
+
+	expected := filepath.Join(home, ".config", "opencode-dashboard", "config.toml")
+	assert.NoError(t, os.MkdirAll(filepath.Dir(expected), 0o755))
+	assert.NoError(t, os.WriteFile(expected, []byte(""), 0o644))
+
+	assert.Equal(t, expected, ResolvePath())
+}
+
+func writeTempConfig(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+	assert.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+	return path
+}

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -1,0 +1,59 @@
+package config
+
+// KeyMap maps actions to key binding strings.
+// Key strings match bubbletea's tea.KeyMsg.String() output.
+// Examples: "ctrl+c", "tab", "enter", "q", " " (space).
+// See: https://pkg.go.dev/github.com/charmbracelet/bubbletea#KeyMsg
+type KeyMap struct {
+	Up          []string
+	Down        []string
+	PaneLeft    []string
+	PaneRight   []string
+	TreeNav     []string
+	Collapse    []string
+	CycleFilter []string
+	CycleTime   []string
+	Search      []string
+	Refresh     []string
+	Launch      []string
+	Quit        []string
+}
+
+// Matches checks if a key string matches any of the provided bindings.
+// It normalizes each binding via NormalizeKey() before comparison.
+// Special case: if keyStr is " " (space) and any binding is "space", returns true.
+func Matches(keyStr string, bindings []string) bool {
+	for _, binding := range bindings {
+		normalized := NormalizeKey(binding)
+		if keyStr == normalized {
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeKey converts "space" to " ", all others unchanged.
+func NormalizeKey(key string) string {
+	if key == "space" {
+		return " "
+	}
+	return key
+}
+
+// DefaultKeyMap returns the default key bindings matching current hardcoded values.
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		Up:          []string{"k", "up"},
+		Down:        []string{"j", "down"},
+		PaneLeft:    []string{"h"},
+		PaneRight:   []string{"l", "right"},
+		TreeNav:     []string{"left"},
+		Collapse:    []string{" "},
+		CycleFilter: []string{"tab"},
+		CycleTime:   []string{"t"},
+		Search:      []string{"/"},
+		Refresh:     []string{"r"},
+		Launch:      []string{"enter"},
+		Quit:        []string{"q", "ctrl+c"},
+	}
+}

--- a/internal/config/keys_test.go
+++ b/internal/config/keys_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatches_SingleKey(t *testing.T) {
+	result := Matches("q", []string{"q"})
+	assert.True(t, result)
+}
+
+func TestMatches_MultipleKeys(t *testing.T) {
+	result := Matches("ctrl+c", []string{"q", "ctrl+c"})
+	assert.True(t, result)
+}
+
+func TestMatches_NoMatch(t *testing.T) {
+	result := Matches("x", []string{"q", "ctrl+c"})
+	assert.False(t, result)
+}
+
+func TestMatches_EmptyBindings(t *testing.T) {
+	result := Matches("q", []string{})
+	assert.False(t, result)
+}
+
+func TestMatches_SpaceAlias(t *testing.T) {
+	result := Matches(" ", []string{"space"})
+	assert.True(t, result)
+}
+
+func TestMatches_SpaceAliasReverse(t *testing.T) {
+	result := Matches(" ", []string{" "})
+	assert.True(t, result)
+}
+
+func TestNormalizeKey(t *testing.T) {
+	assert.Equal(t, " ", NormalizeKey("space"))
+	assert.Equal(t, "q", NormalizeKey("q"))
+}
+
+func TestDefaultKeyMap_MatchesHardcoded(t *testing.T) {
+	km := DefaultKeyMap()
+
+	assert.Equal(t, []string{"k", "up"}, km.Up)
+	assert.Equal(t, []string{"j", "down"}, km.Down)
+	assert.Equal(t, []string{"h"}, km.PaneLeft)
+	assert.Equal(t, []string{"l", "right"}, km.PaneRight)
+	assert.Equal(t, []string{"left"}, km.TreeNav)
+	assert.Equal(t, []string{" "}, km.Collapse)
+	assert.Equal(t, []string{"tab"}, km.CycleFilter)
+	assert.Equal(t, []string{"t"}, km.CycleTime)
+	assert.Equal(t, []string{"/"}, km.Search)
+	assert.Equal(t, []string{"r"}, km.Refresh)
+	assert.Equal(t, []string{"enter"}, km.Launch)
+	assert.Equal(t, []string{"q", "ctrl+c"}, km.Quit)
+}

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -127,39 +127,11 @@ func (f FilterPreset) String() string {
 	}
 }
 
-type TimeWindow int
-
-const (
-	TimeWindowAll TimeWindow = iota
-	TimeWindow1Day
-	TimeWindow3Days
-	TimeWindow7Days
-)
-
-func (w TimeWindow) String() string {
-	switch w {
-	case TimeWindow1Day:
-		return "1d"
-	case TimeWindow3Days:
-		return "3d"
-	case TimeWindow7Days:
-		return "7d"
-	default:
-		return "All"
-	}
-}
-
-func (w TimeWindow) Duration() time.Duration {
-	switch w {
-	case TimeWindow1Day:
-		return 24 * time.Hour
-	case TimeWindow3Days:
-		return 3 * 24 * time.Hour
-	case TimeWindow7Days:
-		return 7 * 24 * time.Hour
-	default:
-		return 0
-	}
+// TimeWindowOption represents a named time window for session filtering.
+// Duration 0 means "all" (no time filtering).
+type TimeWindowOption struct {
+	Label    string
+	Duration time.Duration
 }
 
 // SessionView is the fully-populated view model for a session (used by UI)

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -10,10 +10,10 @@ import (
 type Filter struct {
 	Preset     domain.FilterPreset
 	SearchText string
-	Window     domain.TimeWindow
+	Window     time.Duration
 }
 
-func Apply(sessions []domain.SessionView, f Filter) []domain.SessionView {
+func Apply(sessions []domain.SessionView, f Filter, now time.Time) []domain.SessionView {
 	result := make([]domain.SessionView, 0)
 	for _, s := range sessions {
 		if !matchesPreset(s, f.Preset) {
@@ -22,7 +22,7 @@ func Apply(sessions []domain.SessionView, f Filter) []domain.SessionView {
 		if !matchesSearch(s, f.SearchText) {
 			continue
 		}
-		if !matchesWindow(s, f.Window) {
+		if !matchesWindow(s, f.Window, now) {
 			continue
 		}
 		result = append(result, s)
@@ -52,9 +52,9 @@ func matchesSearch(s domain.SessionView, text string) bool {
 		strings.Contains(strings.ToLower(s.Slug), lower)
 }
 
-func matchesWindow(s domain.SessionView, w domain.TimeWindow) bool {
-	if w == domain.TimeWindowAll {
+func matchesWindow(s domain.SessionView, d time.Duration, now time.Time) bool {
+	if d == 0 {
 		return true
 	}
-	return s.TimeUpdated.After(time.Now().Add(-w.Duration()))
+	return s.TimeUpdated.After(now.Add(-d))
 }

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -14,7 +14,7 @@ type Filter struct {
 }
 
 func Apply(sessions []domain.SessionView, f Filter, now time.Time) []domain.SessionView {
-	result := make([]domain.SessionView, 0)
+	filtered := make([]domain.SessionView, 0)
 	for _, s := range sessions {
 		if !matchesPreset(s, f.Preset) {
 			continue
@@ -25,9 +25,9 @@ func Apply(sessions []domain.SessionView, f Filter, now time.Time) []domain.Sess
 		if !matchesWindow(s, f.Window, now) {
 			continue
 		}
-		result = append(result, s)
+		filtered = append(filtered, s)
 	}
-	return result
+	return filtered
 }
 
 func matchesPreset(s domain.SessionView, preset domain.FilterPreset) bool {

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -85,23 +85,17 @@ func TestApply_ArchivedPreset(t *testing.T) {
 // Test 4: Search "auth" matches title of session 1
 func TestApply_SearchByTitle(t *testing.T) {
 	sessions := makeTestSessions()
-	f := filter.Filter{
-		Preset:     domain.FilterNeedsAttention,
-		SearchText: "auth",
-	}
 
-	// Use FilterNeedsAttention to keep only attention sessions, but "auth" appears in #1
-	// Actually let's use a broader test: search only
-	f2 := filter.Filter{
+	// Use FilterAllActive to keep only active sessions, "auth" appears in #1
+	f := filter.Filter{
 		Preset:     domain.FilterAllActive,
 		SearchText: "auth",
 	}
 
-	result := filter.Apply(sessions, f2, time.Now())
+	result := filter.Apply(sessions, f, time.Now())
 
 	assert.Len(t, result, 1)
 	assert.Equal(t, "1", result[0].ID)
-	_ = f
 }
 
 // Test 5: Search "CI" is case-insensitive and matches slug "setup-ci"

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func fixedNow() time.Time {
+	return time.Date(2026, time.January, 2, 15, 4, 5, 0, time.UTC)
+}
+
 func makeTestSessions() []domain.SessionView {
 	now := time.Now()
 	return []domain.SessionView{
@@ -44,7 +48,7 @@ func TestApply_NeedsAttentionPreset(t *testing.T) {
 	sessions := makeTestSessions()
 	f := filter.Filter{Preset: domain.FilterNeedsAttention}
 
-	result := filter.Apply(sessions, f)
+	result := filter.Apply(sessions, f, time.Now())
 
 	assert.Len(t, result, 2)
 	ids := sessionIDs(result)
@@ -57,7 +61,7 @@ func TestApply_AllActivePreset(t *testing.T) {
 	sessions := makeTestSessions()
 	f := filter.Filter{Preset: domain.FilterAllActive}
 
-	result := filter.Apply(sessions, f)
+	result := filter.Apply(sessions, f, time.Now())
 
 	assert.Len(t, result, 3)
 	ids := sessionIDs(result)
@@ -72,7 +76,7 @@ func TestApply_ArchivedPreset(t *testing.T) {
 	sessions := makeTestSessions()
 	f := filter.Filter{Preset: domain.FilterArchived}
 
-	result := filter.Apply(sessions, f)
+	result := filter.Apply(sessions, f, time.Now())
 
 	assert.Len(t, result, 1)
 	assert.Equal(t, "2", result[0].ID)
@@ -93,7 +97,7 @@ func TestApply_SearchByTitle(t *testing.T) {
 		SearchText: "auth",
 	}
 
-	result := filter.Apply(sessions, f2)
+	result := filter.Apply(sessions, f2, time.Now())
 
 	assert.Len(t, result, 1)
 	assert.Equal(t, "1", result[0].ID)
@@ -108,7 +112,7 @@ func TestApply_SearchCaseInsensitive(t *testing.T) {
 		SearchText: "CI",
 	}
 
-	result := filter.Apply(sessions, f)
+	result := filter.Apply(sessions, f, time.Now())
 
 	assert.Len(t, result, 1)
 	assert.Equal(t, "3", result[0].ID)
@@ -122,7 +126,7 @@ func TestApply_EmptySearchReturnsAll(t *testing.T) {
 		SearchText: "",
 	}
 
-	result := filter.Apply(sessions, f)
+	result := filter.Apply(sessions, f, time.Now())
 
 	// All active: #1, #3, #4
 	assert.Len(t, result, 3)
@@ -136,7 +140,7 @@ func TestApply_CombinedPresetAndSearch(t *testing.T) {
 		SearchText: "auth",
 	}
 
-	result := filter.Apply(sessions, f)
+	result := filter.Apply(sessions, f, time.Now())
 
 	assert.Len(t, result, 1)
 	assert.Equal(t, "1", result[0].ID)
@@ -150,7 +154,7 @@ func TestApply_NoMatchesReturnsEmptySlice(t *testing.T) {
 		SearchText: "zzznomatch",
 	}
 
-	result := filter.Apply(sessions, f)
+	result := filter.Apply(sessions, f, time.Now())
 
 	assert.NotNil(t, result)
 	assert.Len(t, result, 0)
@@ -163,7 +167,7 @@ func TestApply_DoesNotMutateInput(t *testing.T) {
 	copy(original, sessions)
 
 	f := filter.Filter{Preset: domain.FilterNeedsAttention}
-	_ = filter.Apply(sessions, f)
+	_ = filter.Apply(sessions, f, time.Now())
 
 	assert.Equal(t, original, sessions)
 }
@@ -176,8 +180,59 @@ func TestApply_SearchBySlug(t *testing.T) {
 		SearchText: "no-signal",
 	}
 
-	result := filter.Apply(sessions, f)
+	result := filter.Apply(sessions, f, time.Now())
 
 	assert.Len(t, result, 1)
 	assert.Equal(t, "4", result[0].ID)
+}
+
+func TestApply_TimeWindow_All(t *testing.T) {
+	now := fixedNow()
+	sessions := []domain.SessionView{
+		{Session: domain.Session{ID: "recent", TimeUpdated: now.Add(-10 * time.Hour)}},
+		{Session: domain.Session{ID: "old", TimeUpdated: now.Add(-30 * 24 * time.Hour)}},
+	}
+	f := filter.Filter{
+		Preset: domain.FilterAllActive,
+		Window: 0,
+	}
+
+	result := filter.Apply(sessions, f, now)
+
+	assert.Len(t, result, 2)
+	assert.Equal(t, []string{"recent", "old"}, sessionIDs(result))
+}
+
+func TestApply_TimeWindow_1Day(t *testing.T) {
+	now := fixedNow()
+	sessions := []domain.SessionView{
+		{Session: domain.Session{ID: "inside", TimeUpdated: now.Add(-10 * time.Hour)}},
+		{Session: domain.Session{ID: "outside", TimeUpdated: now.Add(-30 * time.Hour)}},
+	}
+	f := filter.Filter{
+		Preset: domain.FilterAllActive,
+		Window: 24 * time.Hour,
+	}
+
+	result := filter.Apply(sessions, f, now)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "inside", result[0].ID)
+}
+
+func TestApply_TimeWindow_Boundary(t *testing.T) {
+	now := fixedNow()
+	sessions := []domain.SessionView{
+		{Session: domain.Session{ID: "boundary", TimeUpdated: now.Add(-24 * time.Hour)}},
+		{Session: domain.Session{ID: "inside", TimeUpdated: now.Add(-23 * time.Hour)}},
+	}
+	f := filter.Filter{
+		Preset: domain.FilterAllActive,
+		Window: 24 * time.Hour,
+	}
+
+	result := filter.Apply(sessions, f, now)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "inside", result[0].ID)
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -198,7 +198,7 @@ func (m *AppModel) applyFilter() {
 		allSessions = append(allSessions, g.Sessions...)
 	}
 
-	filtered := filter.Apply(allSessions, f)
+	filtered := filter.Apply(allSessions, f, time.Now())
 	filteredGroups := regroupSessions(m.allGroups, filtered)
 
 	m.layout.SetGroups(filteredGroups)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -88,6 +88,24 @@ type AppModel struct {
 }
 
 func NewAppWithConfig(cfg config.Config, agg *appcore.Aggregator) AppModel {
+	windowOptions := make([]domain.TimeWindowOption, 0, len(cfg.TimeWindows.Options)+1)
+	for _, opt := range cfg.TimeWindows.Options {
+		windowOptions = append(windowOptions, domain.TimeWindowOption{
+			Label:    opt.Label,
+			Duration: time.Duration(opt.Hours) * time.Hour,
+		})
+	}
+	windowOptions = append(windowOptions, domain.TimeWindowOption{Label: "All", Duration: 0})
+
+	defaultPreset := resolveDefaultPreset(cfg.Defaults.Filter)
+	defaultWindowIdx := 0
+	for i, opt := range windowOptions {
+		if opt.Label == cfg.Defaults.TimeWindow {
+			defaultWindowIdx = i
+			break
+		}
+	}
+
 	hs := lipgloss.NewStyle().
 		Bold(true).
 		Foreground(lipgloss.Color("#FAFAFA")).
@@ -96,9 +114,28 @@ func NewAppWithConfig(cfg config.Config, agg *appcore.Aggregator) AppModel {
 	return AppModel{
 		cfg:         cfg,
 		headerStyle: hs,
-		layout:      NewLayout(nil),
-		aggregator:  agg,
-		loading:     agg != nil,
+		layout: NewLayout(
+			nil,
+			cfg.Keys,
+			cfg.Display,
+			cfg.Defaults.ListWidthRatio,
+			windowOptions,
+			defaultPreset,
+			defaultWindowIdx,
+		),
+		aggregator: agg,
+		loading:    agg != nil,
+	}
+}
+
+func resolveDefaultPreset(filterStr string) domain.FilterPreset {
+	switch filterStr {
+	case "all_active":
+		return domain.FilterAllActive
+	case "archived":
+		return domain.FilterArchived
+	default:
+		return domain.FilterNeedsAttention
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3,22 +3,18 @@ package ui
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
 	appcore "github.com/joeyparis/opencode-dashboard/internal/app"
+	"github.com/joeyparis/opencode-dashboard/internal/config"
 	"github.com/joeyparis/opencode-dashboard/internal/domain"
 	"github.com/joeyparis/opencode-dashboard/internal/filter"
 	"github.com/joeyparis/opencode-dashboard/internal/launcher"
 )
-
-var headerStyle = lipgloss.NewStyle().
-	Bold(true).
-	Foreground(lipgloss.Color("#FAFAFA")).
-	Background(lipgloss.Color("#7D56F4")).
-	Padding(0, 1)
 
 var errorBannerStyle = lipgloss.NewStyle().
 	Bold(true).
@@ -72,21 +68,38 @@ func refreshDataCmd(agg *appcore.Aggregator) tea.Cmd {
 	}
 }
 
-func tickCmd() tea.Cmd {
-	return tea.Tick(30*time.Second, func(t time.Time) tea.Msg {
+func tickCmd(interval time.Duration) tea.Cmd {
+	return tea.Tick(interval, func(t time.Time) tea.Msg {
 		return refreshMsg{}
 	})
 }
 
 type AppModel struct {
-	layout     LayoutModel
-	allGroups  []domain.ProjectGroup
-	width      int
-	height     int
-	aggregator *appcore.Aggregator
-	loading    bool
-	refreshing bool
-	loadErr    error
+	cfg         config.Config
+	headerStyle lipgloss.Style
+	layout      LayoutModel
+	allGroups   []domain.ProjectGroup
+	width       int
+	height      int
+	aggregator  *appcore.Aggregator
+	loading     bool
+	refreshing  bool
+	loadErr     error
+}
+
+func NewAppWithConfig(cfg config.Config, agg *appcore.Aggregator) AppModel {
+	hs := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("#FAFAFA")).
+		Background(lipgloss.Color(cfg.Display.ColorHeader)).
+		Padding(0, 1)
+	return AppModel{
+		cfg:         cfg,
+		headerStyle: hs,
+		layout:      NewLayout(nil),
+		aggregator:  agg,
+		loading:     agg != nil,
+	}
 }
 
 func NewApp() AppModel {
@@ -94,16 +107,13 @@ func NewApp() AppModel {
 }
 
 func NewAppWithAggregator(agg *appcore.Aggregator) AppModel {
-	return AppModel{
-		layout:     NewLayout(nil),
-		aggregator: agg,
-		loading:    agg != nil,
-	}
+	return NewAppWithConfig(config.Default(), agg)
 }
 
 func (m AppModel) Init() tea.Cmd {
+	interval := time.Duration(m.cfg.Defaults.RefreshInterval) * time.Second
 	if m.aggregator != nil {
-		return tea.Batch(m.layout.Init(), loadDataCmd(m.aggregator), tickCmd())
+		return tea.Batch(m.layout.Init(), loadDataCmd(m.aggregator), tickCmd(interval))
 	}
 	return m.layout.Init()
 }
@@ -126,11 +136,12 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case refreshMsg:
+		interval := time.Duration(m.cfg.Defaults.RefreshInterval) * time.Second
 		if m.aggregator == nil {
-			return m, tickCmd()
+			return m, tickCmd(interval)
 		}
 		m.refreshing = true
-		return m, tea.Batch(refreshDataCmd(m.aggregator), tickCmd())
+		return m, tea.Batch(refreshDataCmd(m.aggregator), tickCmd(interval))
 
 	case refreshDataLoadedMsg:
 		selectedID := m.layout.SelectedSessionID()
@@ -169,16 +180,17 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		if msg.String() == "ctrl+c" {
+		keyStr := msg.String()
+		isQuit := config.Matches(keyStr, m.cfg.Keys.Quit)
+		isCtrlC := keyStr == "ctrl+c"
+		if isCtrlC || (isQuit && !m.layout.IsSearchActive()) {
 			return m, tea.Quit
 		}
-		if msg.String() == "q" && !m.layout.IsSearchActive() {
-			return m, tea.Quit
-		}
-		if msg.String() == "r" && !m.layout.IsSearchActive() && m.aggregator != nil && !m.refreshing {
+		if config.Matches(keyStr, m.cfg.Keys.Refresh) && !m.layout.IsSearchActive() && m.aggregator != nil && !m.refreshing {
 			m.refreshing = true
 			return m, refreshDataCmd(m.aggregator)
 		}
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -260,12 +272,16 @@ func (m AppModel) chromeHeight() int {
 	return height
 }
 
+func formatKeys(bindings []string) string {
+	return strings.Join(bindings, "/")
+}
+
 func (m AppModel) View() string {
 	headerText := "OpenCode Dashboard"
 	if m.refreshing {
 		headerText += "  [Refreshing...]"
 	}
-	header := headerStyle.Render(headerText)
+	header := m.headerStyle.Render(headerText)
 	parts := []string{header}
 	if m.loadErr != nil {
 		parts = append(parts, errorBannerStyle.Render(fmt.Sprintf("Error: %v", m.loadErr)))
@@ -274,9 +290,20 @@ func (m AppModel) View() string {
 		parts = append(parts, loadingStyle.Render("Loading..."))
 	}
 	parts = append(parts, m.layout.View())
+	footerText := fmt.Sprintf(
+		"%s up/down  %s/%s pane  \u2190 jump/collapse  %s filter  %s time  %s search  %s refresh  Enter launch  %s quit",
+		formatKeys(m.cfg.Keys.Down),
+		formatKeys(m.cfg.Keys.PaneLeft),
+		formatKeys(m.cfg.Keys.PaneRight),
+		formatKeys(m.cfg.Keys.CycleFilter),
+		formatKeys(m.cfg.Keys.CycleTime),
+		formatKeys(m.cfg.Keys.Search),
+		formatKeys(m.cfg.Keys.Refresh),
+		formatKeys(m.cfg.Keys.Quit),
+	)
 	footer := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#555555")).
-		Render("j/k up/down  h/l pane  ← jump/collapse  Tab filter  t time  / search  r refresh  Enter launch  q quit")
+		Render(footerText)
 	parts = append(parts, footer)
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -260,7 +260,7 @@ func regroupSessions(allGroups []domain.ProjectGroup, filtered []domain.SessionV
 		filteredSet[sv.ID] = struct{}{}
 	}
 
-	result := make([]domain.ProjectGroup, 0, len(allGroups))
+	grouped := make([]domain.ProjectGroup, 0, len(allGroups))
 	for _, g := range allGroups {
 		var sessions []domain.SessionView
 		for _, sv := range g.Sessions {
@@ -277,13 +277,13 @@ func regroupSessions(allGroups []domain.ProjectGroup, filtered []domain.SessionV
 				attentionCount++
 			}
 		}
-		result = append(result, domain.ProjectGroup{
+		grouped = append(grouped, domain.ProjectGroup{
 			Project:        g.Project,
 			Sessions:       sessions,
 			AttentionCount: attentionCount,
 		})
 	}
-	return result
+	return grouped
 }
 
 func (m *AppModel) syncLayoutSize() {

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/joeyparis/opencode-dashboard/internal/config"
 	"github.com/joeyparis/opencode-dashboard/internal/domain"
 )
 
@@ -15,10 +16,13 @@ type DetailModel struct {
 	width        int
 	height       int
 	scrollOffset int
+	display      config.DisplayConfig
 }
 
 func NewDetail() DetailModel {
-	return DetailModel{}
+	return DetailModel{
+		display: config.Default().Display,
+	}
 }
 
 func (m *DetailModel) SetSession(s *domain.SessionView) {
@@ -105,7 +109,7 @@ func (m DetailModel) renderHeader() string {
 	if title == "" {
 		title = m.session.Slug
 	}
-	badge := attentionIcon(m.session.AttentionSignal)
+	badge := attentionIcon(m.session.AttentionSignal, m.display)
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FAFAFA"))
 	return titleStyle.Render(title) + " " + badge
 }

--- a/internal/ui/detail.go
+++ b/internal/ui/detail.go
@@ -19,9 +19,9 @@ type DetailModel struct {
 	display      config.DisplayConfig
 }
 
-func NewDetail() DetailModel {
+func NewDetail(display config.DisplayConfig) DetailModel {
 	return DetailModel{
-		display: config.Default().Display,
+		display: display,
 	}
 }
 
@@ -119,7 +119,7 @@ func (m DetailModel) renderMetadata() string {
 		return ""
 	}
 	s := m.session
-	header := sectionHeaderStyle.Render("Metadata")
+	header := sectionHeaderStyle(m.display.ColorHeader).Render("Metadata")
 
 	relTime := relativeTime(s.TimeUpdated)
 	absTime := s.TimeUpdated.Format("Jan 2 15:04")
@@ -140,7 +140,7 @@ func (m DetailModel) renderStats() string {
 		return ""
 	}
 	s := m.session
-	header := sectionHeaderStyle.Render("Stats")
+	header := sectionHeaderStyle(m.display.ColorHeader).Render("Stats")
 
 	lines := []string{
 		header,
@@ -171,7 +171,7 @@ func (m DetailModel) renderTodos() string {
 		return ""
 	}
 
-	header := sectionHeaderStyle.Render("Todos")
+	header := sectionHeaderStyle(m.display.ColorHeader).Render("Todos")
 	lines := []string{header}
 
 	for _, todo := range m.session.Todos {
@@ -192,7 +192,7 @@ func (m DetailModel) renderLastActivity() string {
 		return ""
 	}
 
-	header := sectionHeaderStyle.Render("Last Activity")
+	header := sectionHeaderStyle(m.display.ColorHeader).Render("Last Activity")
 	lines := []string{header}
 
 	if lm.Agent != "" {

--- a/internal/ui/filterbar.go
+++ b/internal/ui/filterbar.go
@@ -19,26 +19,34 @@ type FilterChangedMsg struct {
 
 // FilterBarModel is the filter bar UI component rendered above the split panes.
 type FilterBarModel struct {
-	preset     domain.FilterPreset
-	window     domain.TimeWindow
-	searchMode bool
-	textInput  textinput.Model
-	shownCount int
-	totalCount int
-	width      int
+	preset        domain.FilterPreset
+	windowOptions []domain.TimeWindowOption
+	windowIdx     int
+	searchMode    bool
+	textInput     textinput.Model
+	shownCount    int
+	totalCount    int
+	width         int
 }
 
 func (m *FilterBarModel) SetWidth(w int) { m.width = w }
 
 // NewFilterBar creates a new FilterBarModel defaulting to NeedsAttention.
-func NewFilterBar() FilterBarModel {
+func NewFilterBar(windowOptions []domain.TimeWindowOption, defaultWindowIdx int) FilterBarModel {
 	ti := textinput.New()
 	ti.Placeholder = "Search..."
 	ti.CharLimit = 100
+	if len(windowOptions) == 0 {
+		windowOptions = []domain.TimeWindowOption{{Label: "All", Duration: 0}}
+	}
+	if defaultWindowIdx < 0 || defaultWindowIdx >= len(windowOptions) {
+		defaultWindowIdx = 0
+	}
 	return FilterBarModel{
-		preset:    domain.FilterNeedsAttention,
-		window:    domain.TimeWindow3Days,
-		textInput: ti,
+		preset:        domain.FilterNeedsAttention,
+		windowOptions: windowOptions,
+		windowIdx:     defaultWindowIdx,
+		textInput:     ti,
 	}
 }
 
@@ -52,7 +60,7 @@ func (m FilterBarModel) CurrentFilter() filter.Filter {
 	return filter.Filter{
 		Preset:     m.preset,
 		SearchText: m.textInput.Value(),
-		Window:     m.window,
+		Window:     m.windowOptions[m.windowIdx].Duration,
 	}
 }
 
@@ -91,7 +99,7 @@ func (m FilterBarModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.preset = nextPreset(m.preset)
 			return m, emitFilterChanged(m)
 		case "t":
-			m.window = nextWindow(m.window)
+			m.windowIdx = (m.windowIdx + 1) % len(m.windowOptions)
 			return m, emitFilterChanged(m)
 		case "/":
 			m.searchMode = true
@@ -133,7 +141,7 @@ func (m FilterBarModel) View() string {
 
 	filterPart := "Filter: " + strings.Join(presetStrs, " | ")
 
-	windowPart := "Time: " + m.window.String()
+	windowPart := "Time: " + m.windowOptions[m.windowIdx].Label
 
 	var searchPart string
 	switch {
@@ -179,24 +187,11 @@ func nextPreset(p domain.FilterPreset) domain.FilterPreset {
 	}
 }
 
-func nextWindow(w domain.TimeWindow) domain.TimeWindow {
-	switch w {
-	case domain.TimeWindowAll:
-		return domain.TimeWindow1Day
-	case domain.TimeWindow1Day:
-		return domain.TimeWindow3Days
-	case domain.TimeWindow3Days:
-		return domain.TimeWindow7Days
-	default:
-		return domain.TimeWindowAll
-	}
-}
-
 func emitFilterChanged(m FilterBarModel) tea.Cmd {
 	f := filter.Filter{
 		Preset:     m.preset,
 		SearchText: m.textInput.Value(),
-		Window:     m.window,
+		Window:     m.windowOptions[m.windowIdx].Duration,
 	}
 	return func() tea.Msg {
 		return FilterChangedMsg{Filter: f}

--- a/internal/ui/filterbar.go
+++ b/internal/ui/filterbar.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/joeyparis/opencode-dashboard/internal/config"
 	"github.com/joeyparis/opencode-dashboard/internal/domain"
 	"github.com/joeyparis/opencode-dashboard/internal/filter"
 )
@@ -19,6 +20,8 @@ type FilterChangedMsg struct {
 
 // FilterBarModel is the filter bar UI component rendered above the split panes.
 type FilterBarModel struct {
+	keys          config.KeysConfig
+	display       config.DisplayConfig
 	preset        domain.FilterPreset
 	windowOptions []domain.TimeWindowOption
 	windowIdx     int
@@ -31,8 +34,8 @@ type FilterBarModel struct {
 
 func (m *FilterBarModel) SetWidth(w int) { m.width = w }
 
-// NewFilterBar creates a new FilterBarModel defaulting to NeedsAttention.
-func NewFilterBar(windowOptions []domain.TimeWindowOption, defaultWindowIdx int) FilterBarModel {
+// NewFilterBar creates a new FilterBarModel with the given config and defaults.
+func NewFilterBar(keys config.KeysConfig, display config.DisplayConfig, windowOptions []domain.TimeWindowOption, defaultPreset domain.FilterPreset, defaultWindowIdx int) FilterBarModel {
 	ti := textinput.New()
 	ti.Placeholder = "Search..."
 	ti.CharLimit = 100
@@ -43,7 +46,9 @@ func NewFilterBar(windowOptions []domain.TimeWindowOption, defaultWindowIdx int)
 		defaultWindowIdx = 0
 	}
 	return FilterBarModel{
-		preset:        domain.FilterNeedsAttention,
+		keys:          keys,
+		display:       display,
+		preset:        defaultPreset,
 		windowOptions: windowOptions,
 		windowIdx:     defaultWindowIdx,
 		textInput:     ti,
@@ -94,14 +99,14 @@ func (m FilterBarModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, cmd
 			}
 		}
-		switch msg.String() {
-		case "tab":
+		switch {
+		case config.Matches(msg.String(), m.keys.CycleFilter):
 			m.preset = nextPreset(m.preset)
 			return m, emitFilterChanged(m)
-		case "t":
+		case config.Matches(msg.String(), m.keys.CycleTime):
 			m.windowIdx = (m.windowIdx + 1) % len(m.windowOptions)
 			return m, emitFilterChanged(m)
-		case "/":
+		case config.Matches(msg.String(), m.keys.Search):
 			m.searchMode = true
 			cmd := m.textInput.Focus()
 			return m, cmd
@@ -131,7 +136,7 @@ func (m FilterBarModel) View() string {
 			s := lipgloss.NewStyle().
 				Bold(true).
 				Foreground(lipgloss.Color("#FFFFFF")).
-				Background(lipgloss.Color("#7D56F4"))
+				Background(lipgloss.Color(m.display.ColorHeader))
 			presetStrs = append(presetStrs, s.Render("["+label+"]"))
 		} else {
 			s := lipgloss.NewStyle().Foreground(lipgloss.Color("#888888"))
@@ -159,12 +164,12 @@ func (m FilterBarModel) View() string {
 		return lipgloss.NewStyle().Foreground(lipgloss.Color(c)).Render(text)
 	}
 	legend := strings.Join([]string{
-		color("#FF0000", "!") + " err",
-		color("#FF44FF", "@") + " waiting",
-		color("#00FF00", "*") + " active",
-		color("#FFFF00", "?") + " reply",
-		color("#FFA500", "~") + " stale",
-		color("#0088FF", ".") + " todos",
+		color(m.display.ColorError, m.display.IconError) + " err",
+		color(m.display.ColorWaiting, m.display.IconWaiting) + " waiting",
+		color(m.display.ColorActive, m.display.IconActive) + " active",
+		color(m.display.ColorReply, m.display.IconReply) + " reply",
+		color(m.display.ColorStale, m.display.IconStale) + " stale",
+		color(m.display.ColorTodos, m.display.IconTodos) + " todos",
 	}, "  ")
 	left := strings.Join([]string{filterPart, windowPart, searchPart, counterPart}, "  ")
 	if m.width > 0 {

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -40,7 +40,7 @@ func NewLayout(
 	return LayoutModel{
 		filterBar:      NewFilterBar(keys, display, windowOptions, defaultPreset, defaultWindowIdx),
 		list:           NewSessionList(groups, keys, display),
-		detail:         NewDetail(),
+		detail:         NewDetail(display),
 		keys:           keys,
 		display:        display,
 		listWidthRatio: listWidthRatio,

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -25,8 +27,14 @@ type LayoutModel struct {
 }
 
 func NewLayout(groups []domain.ProjectGroup) LayoutModel {
+	defaultOptions := []domain.TimeWindowOption{
+		{Label: "1d", Duration: 24 * time.Hour},
+		{Label: "3d", Duration: 72 * time.Hour},
+		{Label: "7d", Duration: 168 * time.Hour},
+		{Label: "All", Duration: 0},
+	}
 	return LayoutModel{
-		filterBar: NewFilterBar(),
+		filterBar: NewFilterBar(defaultOptions, 1),
 		list:      NewSessionList(groups),
 		detail:    NewDetail(),
 	}
@@ -74,18 +82,9 @@ func (m LayoutModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		leftWidth, rightWidth := m.paneWidths()
 		borderAndTitle := 3
-		contentH := m.height - filterBarHeight - borderAndTitle
-		if contentH < 0 {
-			contentH = 0
-		}
-		leftInnerW := leftWidth - 2
-		if leftInnerW < 0 {
-			leftInnerW = 0
-		}
-		rightInnerW := rightWidth - 2
-		if rightInnerW < 0 {
-			rightInnerW = 0
-		}
+		contentH := max(0, m.height-filterBarHeight-borderAndTitle)
+		leftInnerW := max(0, leftWidth-2)
+		rightInnerW := max(0, rightWidth-2)
 		m.list.SetSize(leftInnerW, contentH)
 		m.detail.SetSize(rightInnerW, contentH)
 		m.filterBar.SetWidth(m.width)
@@ -193,18 +192,9 @@ func (m LayoutModel) View() string {
 		rightBorderColor = activeColor
 	}
 
-	leftInnerW := leftWidth - 2
-	if leftInnerW < 0 {
-		leftInnerW = 0
-	}
-	rightInnerW := rightWidth - 2
-	if rightInnerW < 0 {
-		rightInnerW = 0
-	}
-	paneInnerH := m.height - filterBarHeight - 2
-	if paneInnerH < 1 {
-		paneInnerH = 1
-	}
+	leftInnerW := max(0, leftWidth-2)
+	rightInnerW := max(0, rightWidth-2)
+	paneInnerH := max(1, m.height-filterBarHeight-2)
 
 	leftPane := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
@@ -226,9 +216,6 @@ func (m LayoutModel) View() string {
 
 func (m LayoutModel) paneWidths() (left, right int) {
 	left = m.width / 2
-	right = m.width - left - 1
-	if right < 0 {
-		right = 0
-	}
+	right = max(0, m.width-left-1)
 	return left, right
 }

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -6,6 +6,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/joeyparis/opencode-dashboard/internal/config"
 	"github.com/joeyparis/opencode-dashboard/internal/domain"
 	"github.com/joeyparis/opencode-dashboard/internal/filter"
 )
@@ -34,8 +35,8 @@ func NewLayout(groups []domain.ProjectGroup) LayoutModel {
 		{Label: "All", Duration: 0},
 	}
 	return LayoutModel{
-		filterBar: NewFilterBar(defaultOptions, 1),
-		list:      NewSessionList(groups),
+		filterBar: NewFilterBar(config.Default().Keys, config.Default().Display, defaultOptions, domain.FilterNeedsAttention, 1),
+		list:      NewSessionList(groups, config.Default().Keys, config.Default().Display),
 		detail:    NewDetail(),
 	}
 }

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -1,8 +1,6 @@
 package ui
 
 import (
-	"time"
-
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -19,25 +17,33 @@ const (
 )
 
 type LayoutModel struct {
-	filterBar  FilterBarModel
-	list       SessionListModel
-	detail     DetailModel
-	activePane int
-	width      int
-	height     int
+	filterBar      FilterBarModel
+	list           SessionListModel
+	detail         DetailModel
+	activePane     int
+	width          int
+	height         int
+	keys           config.KeysConfig
+	display        config.DisplayConfig
+	listWidthRatio float64
 }
 
-func NewLayout(groups []domain.ProjectGroup) LayoutModel {
-	defaultOptions := []domain.TimeWindowOption{
-		{Label: "1d", Duration: 24 * time.Hour},
-		{Label: "3d", Duration: 72 * time.Hour},
-		{Label: "7d", Duration: 168 * time.Hour},
-		{Label: "All", Duration: 0},
-	}
+func NewLayout(
+	groups []domain.ProjectGroup,
+	keys config.KeysConfig,
+	display config.DisplayConfig,
+	listWidthRatio float64,
+	windowOptions []domain.TimeWindowOption,
+	defaultPreset domain.FilterPreset,
+	defaultWindowIdx int,
+) LayoutModel {
 	return LayoutModel{
-		filterBar: NewFilterBar(config.Default().Keys, config.Default().Display, defaultOptions, domain.FilterNeedsAttention, 1),
-		list:      NewSessionList(groups, config.Default().Keys, config.Default().Display),
-		detail:    NewDetail(),
+		filterBar:      NewFilterBar(keys, display, windowOptions, defaultPreset, defaultWindowIdx),
+		list:           NewSessionList(groups, keys, display),
+		detail:         NewDetail(),
+		keys:           keys,
+		display:        display,
+		listWidthRatio: listWidthRatio,
 	}
 }
 
@@ -93,13 +99,13 @@ func (m LayoutModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		// Tab always cycles filter presets.
-		if msg.String() == "tab" {
+		if config.Matches(msg.String(), m.keys.CycleFilter) {
 			updated, cmd := m.filterBar.Update(msg)
 			m.filterBar = updated.(FilterBarModel)
 			return m, cmd
 		}
 
-		if msg.String() == "t" && !m.filterBar.IsSearchMode() {
+		if config.Matches(msg.String(), m.keys.CycleTime) && !m.filterBar.IsSearchMode() {
 			updated, cmd := m.filterBar.Update(msg)
 			m.filterBar = updated.(FilterBarModel)
 			return m, cmd
@@ -113,14 +119,14 @@ func (m LayoutModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// '/' activates search.
-		if msg.String() == "/" {
+		if config.Matches(msg.String(), m.keys.Search) {
 			updated, cmd := m.filterBar.Update(msg)
 			m.filterBar = updated.(FilterBarModel)
 			return m, cmd
 		}
 
 		// Left arrow: switch pane from right→left, or tree-nav within left pane.
-		if msg.String() == "left" {
+		if config.Matches(msg.String(), m.keys.TreeNav) {
 			if m.activePane == paneRight {
 				m.activePane = paneLeft
 				return m, nil
@@ -132,14 +138,15 @@ func (m LayoutModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Pane switching.
-		switch msg.String() {
-		case "h":
+		if config.Matches(msg.String(), m.keys.PaneLeft) {
 			m.activePane = paneLeft
 			return m, nil
-		case "l", "right":
+		}
+		if config.Matches(msg.String(), m.keys.PaneRight) {
 			m.activePane = paneRight
 			return m, nil
-		case "enter":
+		}
+		if config.Matches(msg.String(), m.keys.Launch) {
 			if m.activePane == paneLeft {
 				if sel := m.list.SelectedSession(); sel != nil {
 					return m, func() tea.Msg { return launchSessionMsg{session: sel} }
@@ -182,7 +189,7 @@ func (m LayoutModel) View() string {
 		rightTitle = "[*] Details"
 	}
 
-	activeColor := lipgloss.Color("#7D56F4")
+	activeColor := lipgloss.Color(m.display.ColorHeader)
 	inactiveColor := lipgloss.Color("#555555")
 
 	leftBorderColor := inactiveColor
@@ -216,7 +223,7 @@ func (m LayoutModel) View() string {
 }
 
 func (m LayoutModel) paneWidths() (left, right int) {
-	left = m.width / 2
+	left = int(float64(m.width) * m.listWidthRatio)
 	right = max(0, m.width-left-1)
 	return left, right
 }

--- a/internal/ui/sessionlist.go
+++ b/internal/ui/sessionlist.go
@@ -32,16 +32,18 @@ type SessionListModel struct {
 	collapsed map[string]bool // project ID -> collapsed
 	width     int
 	height    int
+	keys      config.KeysConfig
 	display   config.DisplayConfig
 }
 
 // NewSessionList constructs a SessionListModel with the given data.
-func NewSessionList(groups []domain.ProjectGroup) SessionListModel {
+func NewSessionList(groups []domain.ProjectGroup, keys config.KeysConfig, display config.DisplayConfig) SessionListModel {
 	return SessionListModel{
 		groups:    groups,
 		cursor:    0,
 		collapsed: make(map[string]bool),
-		display:   config.Default().Display,
+		keys:      keys,
+		display:   display,
 	}
 }
 
@@ -108,23 +110,24 @@ func (m SessionListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		rows := m.buildVisibleRows()
-		switch msg.String() {
-		case "j", "down":
+		keyStr := msg.String()
+		switch {
+		case config.Matches(keyStr, m.keys.Down):
 			if m.cursor < len(rows)-1 {
 				m.cursor++
 			}
-		case "k", "up":
+		case config.Matches(keyStr, m.keys.Up):
 			if m.cursor > 0 {
 				m.cursor--
 			}
-		case " ":
+		case config.Matches(keyStr, m.keys.Collapse):
 			if len(rows) > 0 && m.cursor < len(rows) {
 				row := rows[m.cursor]
 				if row.kind == rowProject {
 					m.collapsed[row.projectID] = !m.collapsed[row.projectID]
 				}
 			}
-		case "left":
+		case config.Matches(keyStr, m.keys.TreeNav):
 			if len(rows) > 0 && m.cursor < len(rows) {
 				row := rows[m.cursor]
 				if row.kind == rowSession {

--- a/internal/ui/sessionlist.go
+++ b/internal/ui/sessionlist.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/joeyparis/opencode-dashboard/internal/config"
 	"github.com/joeyparis/opencode-dashboard/internal/domain"
 )
 
@@ -31,6 +32,7 @@ type SessionListModel struct {
 	collapsed map[string]bool // project ID -> collapsed
 	width     int
 	height    int
+	display   config.DisplayConfig
 }
 
 // NewSessionList constructs a SessionListModel with the given data.
@@ -39,6 +41,7 @@ func NewSessionList(groups []domain.ProjectGroup) SessionListModel {
 		groups:    groups,
 		cursor:    0,
 		collapsed: make(map[string]bool),
+		display:   config.Default().Display,
 	}
 }
 
@@ -226,9 +229,9 @@ func (m SessionListModel) renderProjectRow(row visibleRow, selected bool) string
 func (m SessionListModel) renderSessionRow(row visibleRow, selected bool) string {
 	sv := m.groups[row.groupIdx].Sessions[row.sessionIdx]
 
-	icon := attentionIconPlain(sv.AttentionSignal)
+	icon := attentionIconPlain(sv.AttentionSignal, m.display)
 	if !selected {
-		icon = attentionIcon(sv.AttentionSignal)
+		icon = attentionIcon(sv.AttentionSignal, m.display)
 	}
 
 	// Prefer the session title; fall back to slug for default/empty titles

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -10,9 +10,11 @@ import (
 	"github.com/joeyparis/opencode-dashboard/internal/domain"
 )
 
-var sectionHeaderStyle = lipgloss.NewStyle().
-	Bold(true).
-	Foreground(lipgloss.Color("#7D56F4"))
+func sectionHeaderStyle(colorHeader string) lipgloss.Style {
+	return lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color(colorHeader))
+}
 
 func iconAndColor(signal domain.AttentionSignal, d config.DisplayConfig) (string, string) {
 	switch signal {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/joeyparis/opencode-dashboard/internal/config"
 	"github.com/joeyparis/opencode-dashboard/internal/domain"
 )
 
@@ -13,42 +14,39 @@ var sectionHeaderStyle = lipgloss.NewStyle().
 	Bold(true).
 	Foreground(lipgloss.Color("#7D56F4"))
 
-func attentionIcon(signal domain.AttentionSignal) string {
+func iconAndColor(signal domain.AttentionSignal, d config.DisplayConfig) (string, string) {
 	switch signal {
 	case domain.HasErrors:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000")).Render("!")
+		return d.IconError, d.ColorError
 	case domain.WaitingForInput:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("#FF44FF")).Render("@")
+		return d.IconWaiting, d.ColorWaiting
 	case domain.ActiveNow:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00")).Render("*")
+		return d.IconActive, d.ColorActive
 	case domain.NeedsResponse:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("#FFFF00")).Render("?")
+		return d.IconReply, d.ColorReply
 	case domain.StaleWork:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("#FFA500")).Render("~")
+		return d.IconStale, d.ColorStale
 	case domain.PendingTodos:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("#0088FF")).Render(".")
+		return d.IconTodos, d.ColorTodos
 	default:
-		return " "
+		return "", ""
 	}
 }
 
-func attentionIconPlain(signal domain.AttentionSignal) string {
-	switch signal {
-	case domain.HasErrors:
-		return "!"
-	case domain.WaitingForInput:
-		return "@"
-	case domain.ActiveNow:
-		return "*"
-	case domain.NeedsResponse:
-		return "?"
-	case domain.StaleWork:
-		return "~"
-	case domain.PendingTodos:
-		return "."
-	default:
+func attentionIcon(signal domain.AttentionSignal, d config.DisplayConfig) string {
+	icon, color := iconAndColor(signal, d)
+	if icon == "" {
 		return " "
 	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(color)).Render(icon)
+}
+
+func attentionIconPlain(signal domain.AttentionSignal, d config.DisplayConfig) string {
+	icon, _ := iconAndColor(signal, d)
+	if icon == "" {
+		return " "
+	}
+	return icon
 }
 
 func relativeTime(t time.Time) string {


### PR DESCRIPTION
## Summary

Closes #1. Adds an optional TOML config file (`~/.config/opencode-dashboard/config.toml`) so users can customize keybindings, default filters/time windows, attention thresholds, and display colors/icons without recompiling.

- New `internal/config/` package with `Config` struct, `Load()` with XDG path resolution, `Validate()`, and `KeyMap` with `Matches()` helper
- Configurable attention thresholds via `ClassifyWith()` alongside backward-compatible `Classify()` wrapper
- `TimeWindow` enum replaced with config-driven `[]TimeWindowOption` slice (custom windows, "All" always appended last)
- All UI components (filterbar, sessionlist, layout, app, detail) wired to accept config for keys, icons, colors, split ratio, refresh interval
- `--config` flag in main.go; missing file = silent defaults, parse error = clear exit, explicit missing path = error
- 23 new tests (config loading/validation, key matching, configurable thresholds, time window filtering)

## What changed

| Area | Files | What |
|------|-------|------|
| Config package | `internal/config/config.go`, `keys.go` + tests | TOML loading, validation, KeyMap matching |
| Attention | `internal/attention/classifier.go` + tests | `Thresholds` struct, `ClassifyWith()` |
| Domain | `internal/domain/types.go` | `TimeWindowOption` replaces `TimeWindow` enum |
| Filter | `internal/filter/filter.go` + tests | `Apply()` gains `now` param, duration-based windows |
| UI | `filterbar.go`, `sessionlist.go`, `layout.go`, `app.go`, `styles.go`, `detail.go` | Config-driven keys/icons/colors/ratio/refresh |
| App | `internal/app/aggregator.go` | `NewAggregatorWithClassifier()` added |
| Entry | `cmd/opencode-dashboard/main.go` | `--config` flag, threshold bridging |

## Backward compatibility

All existing behavior is preserved when no config file exists. `Default()` values exactly match every previously-hardcoded constant. Existing `NewAggregator()` and `NewAppWithAggregator()` signatures are unchanged (wrappers using defaults).

## Verification

- `go test ./...` passes (all existing + 23 new tests)
- `go vet ./...` clean
- `go build ./cmd/opencode-dashboard` succeeds
- 4-reviewer Final Verification Wave passed: Plan Compliance (oracle), Code Quality, Manual QA (7 scenarios), Scope Fidelity